### PR TITLE
Enhancement:  copy last workfile as reusable methods

### DIFF
--- a/openpype/client/entities.py
+++ b/openpype/client/entities.py
@@ -1,8 +1,6 @@
 """Unclear if these will have public functions like these.
-
 Goal is that most of functions here are called on (or with) an object
 that has project name as a context (e.g. on 'ProjectEntity'?).
-
 + We will need more specific functions doing wery specific queires really fast.
 """
 
@@ -21,7 +19,10 @@ def _prepare_fields(fields, required_fields=None):
     if not fields:
         return None
 
-    output = {field: True for field in fields}
+    output = {
+        field: True
+        for field in fields
+    }
     if "_id" not in output:
         output["_id"] = True
 
@@ -33,11 +34,9 @@ def _prepare_fields(fields, required_fields=None):
 
 def convert_id(in_id):
     """Helper function for conversion of id from string to ObjectId.
-
     Args:
         in_id (Union[str, ObjectId, Any]): Entity id that should be converted
             to right type for queries.
-
     Returns:
         Union[ObjectId, Any]: Converted ids to ObjectId or in type.
     """
@@ -49,11 +48,9 @@ def convert_id(in_id):
 
 def convert_ids(in_ids):
     """Helper function for conversion of ids from string to ObjectId.
-
     Args:
         in_ids (Iterable[Union[str, ObjectId, Any]]): List of entity ids that
             should be converted to right type for queries.
-
     Returns:
         List[ObjectId]: Converted ids to ObjectId.
     """
@@ -107,10 +104,8 @@ def get_project(project_name, active=True, inactive=True, fields=None):
 
 def get_whole_project(project_name):
     """Receive all documents from project.
-
     Helper that can be used to get all document from whole project. For example
     for backups etc.
-
     Returns:
         Cursor: Query cursor as iterable which returns all documents from
             project collection.
@@ -122,13 +117,11 @@ def get_whole_project(project_name):
 
 def get_asset_by_id(project_name, asset_id, fields=None):
     """Receive asset data by it's id.
-
     Args:
         project_name (str): Name of project where to look for queried entities.
         asset_id (Union[str, ObjectId]): Asset's id.
         fields (Iterable[str]): Fields that should be returned. All fields are
             returned if 'None' is passed.
-
     Returns:
         dict: Asset entity data.
         None: Asset was not found by id.
@@ -145,13 +138,11 @@ def get_asset_by_id(project_name, asset_id, fields=None):
 
 def get_asset_by_name(project_name, asset_name, fields=None):
     """Receive asset data by it's name.
-
     Args:
         project_name (str): Name of project where to look for queried entities.
         asset_name (str): Asset's name.
         fields (Iterable[str]): Fields that should be returned. All fields are
             returned if 'None' is passed.
-
     Returns:
         dict: Asset entity data.
         None: Asset was not found by name.
@@ -175,15 +166,12 @@ def _get_assets(
     parent_ids=None,
     standard=True,
     archived=False,
-    fields=None,
+    fields=None
 ):
     """Assets for specified project by passed filters.
-
     Passed filters (ids and names) are always combined so all conditions must
     match.
-
     To receive all assets from project just keep filters empty.
-
     Args:
         project_name (str): Name of project where to look for queried entities.
         asset_ids (Iterable[Union[str, ObjectId]]): Asset ids that should
@@ -194,7 +182,6 @@ def _get_assets(
         archived (bool): Query archived assets (type 'archived_asset').
         fields (Iterable[str]): Fields that should be returned. All fields are
             returned if 'None' is passed.
-
     Returns:
         Cursor: Query cursor as iterable which returns asset documents matching
             passed filters.
@@ -242,15 +229,12 @@ def get_assets(
     asset_names=None,
     parent_ids=None,
     archived=False,
-    fields=None,
+    fields=None
 ):
     """Assets for specified project by passed filters.
-
     Passed filters (ids and names) are always combined so all conditions must
     match.
-
     To receive all assets from project just keep filters empty.
-
     Args:
         project_name (str): Name of project where to look for queried entities.
         asset_ids (Iterable[Union[str, ObjectId]]): Asset ids that should
@@ -260,7 +244,6 @@ def get_assets(
         archived (bool): Add also archived assets.
         fields (Iterable[str]): Fields that should be returned. All fields are
             returned if 'None' is passed.
-
     Returns:
         Cursor: Query cursor as iterable which returns asset documents matching
             passed filters.
@@ -273,7 +256,7 @@ def get_assets(
         parent_ids,
         True,
         archived,
-        fields,
+        fields
     )
 
 
@@ -282,15 +265,12 @@ def get_archived_assets(
     asset_ids=None,
     asset_names=None,
     parent_ids=None,
-    fields=None,
+    fields=None
 ):
     """Archived assets for specified project by passed filters.
-
     Passed filters (ids and names) are always combined so all conditions must
     match.
-
     To receive all archived assets from project just keep filters empty.
-
     Args:
         project_name (str): Name of project where to look for queried entities.
         asset_ids (Iterable[Union[str, ObjectId]]): Asset ids that should
@@ -299,7 +279,6 @@ def get_archived_assets(
         parent_ids (Iterable[Union[str, ObjectId]]): Parent asset ids.
         fields (Iterable[str]): Fields that should be returned. All fields are
             returned if 'None' is passed.
-
     Returns:
         Cursor: Query cursor as iterable which returns asset documents matching
             passed filters.
@@ -312,17 +291,17 @@ def get_archived_assets(
 
 def get_asset_ids_with_subsets(project_name, asset_ids=None):
     """Find out which assets have existing subsets.
-
     Args:
         project_name (str): Name of project where to look for queried entities.
         asset_ids (Iterable[Union[str, ObjectId]]): Look only for entered
             asset ids.
-
     Returns:
         Iterable[ObjectId]: Asset ids that have existing subsets.
     """
 
-    subset_query = {"type": "subset"}
+    subset_query = {
+        "type": "subset"
+    }
     if asset_ids is not None:
         asset_ids = convert_ids(asset_ids)
         if not asset_ids:
@@ -330,12 +309,17 @@ def get_asset_ids_with_subsets(project_name, asset_ids=None):
         subset_query["parent"] = {"$in": asset_ids}
 
     conn = get_project_connection(project_name)
-    result = conn.aggregate(
-        [
-            {"$match": subset_query},
-            {"$group": {"_id": "$parent", "count": {"$sum": 1}}},
-        ]
-    )
+    result = conn.aggregate([
+        {
+            "$match": subset_query
+        },
+        {
+            "$group": {
+                "_id": "$parent",
+                "count": {"$sum": 1}
+            }
+        }
+    ])
     asset_ids_with_subsets = []
     for item in result:
         asset_id = item["_id"]
@@ -347,13 +331,11 @@ def get_asset_ids_with_subsets(project_name, asset_ids=None):
 
 def get_subset_by_id(project_name, subset_id, fields=None):
     """Single subset entity data by it's id.
-
     Args:
         project_name (str): Name of project where to look for queried entities.
         subset_id (Union[str, ObjectId]): Id of subset which should be found.
         fields (Iterable[str]): Fields that should be returned. All fields are
             returned if 'None' is passed.
-
     Returns:
         None: If subset with specified filters was not found.
         Dict: Subset document which can be reduced to specified 'fields'.
@@ -370,14 +352,12 @@ def get_subset_by_id(project_name, subset_id, fields=None):
 
 def get_subset_by_name(project_name, subset_name, asset_id, fields=None):
     """Single subset entity data by it's name and it's version id.
-
     Args:
         project_name (str): Name of project where to look for queried entities.
         subset_name (str): Name of subset.
         asset_id (Union[str, ObjectId]): Id of parent asset.
         fields (Iterable[str]): Fields that should be returned. All fields are
             returned if 'None' is passed.
-
     Returns:
         None: If subset with specified filters was not found.
         Dict: Subset document which can be reduced to specified 'fields'.
@@ -390,7 +370,11 @@ def get_subset_by_name(project_name, subset_name, asset_id, fields=None):
     if not asset_id:
         return None
 
-    query_filters = {"type": "subset", "name": subset_name, "parent": asset_id}
+    query_filters = {
+        "type": "subset",
+        "name": subset_name,
+        "parent": asset_id
+    }
     conn = get_project_connection(project_name)
     return conn.find_one(query_filters, _prepare_fields(fields))
 
@@ -402,12 +386,10 @@ def get_subsets(
     asset_ids=None,
     names_by_asset_ids=None,
     archived=False,
-    fields=None,
+    fields=None
 ):
     """Subset entities data from one project filtered by entered filters.
-
     Filters are additive (all conditions must pass to return subset).
-
     Args:
         project_name (str): Name of project where to look for queried entities.
         subset_ids (Iterable[Union[str, ObjectId]]): Subset ids that should be
@@ -421,7 +403,6 @@ def get_subsets(
         archived (bool): Look for archived subsets too.
         fields (Iterable[str]): Fields that should be returned. All fields are
             returned if 'None' is passed.
-
     Returns:
         Cursor: Iterable cursor yielding all matching subsets.
     """
@@ -456,19 +437,17 @@ def get_subsets(
         or_query = []
         for asset_id, names in names_by_asset_ids.items():
             if asset_id and names:
-                or_query.append(
-                    {
-                        "parent": convert_id(asset_id),
-                        "name": {"$in": list(names)},
-                    }
-                )
+                or_query.append({
+                    "parent": convert_id(asset_id),
+                    "name": {"$in": list(names)}
+                })
         if not or_query:
             return []
         query_filter["$or"] = or_query
 
     conn = get_project_connection(project_name)
     return conn.find(query_filter, _prepare_fields(fields))
-
+	
 
 def match_subset_id(
     project_name: str, task_name: str, family: str, asset_doc: dict
@@ -521,41 +500,33 @@ def match_subset_id(
 
 def get_subset_families(project_name, subset_ids=None):
     """Set of main families of subsets.
-
     Args:
         project_name (str): Name of project where to look for queried entities.
         subset_ids (Iterable[Union[str, ObjectId]]): Subset ids that should
             be queried. All subsets from project are used if 'None' is passed.
-
     Returns:
          set[str]: Main families of matching subsets.
     """
 
-    subset_filter = {"type": "subset"}
+    subset_filter = {
+        "type": "subset"
+    }
     if subset_ids is not None:
         if not subset_ids:
             return set()
         subset_filter["_id"] = {"$in": list(subset_ids)}
 
     conn = get_project_connection(project_name)
-    result = list(
-        conn.aggregate(
-            [
-                {"$match": subset_filter},
-                {
-                    "$project": {
-                        "family": {"$arrayElemAt": ["$data.families", 0]}
-                    }
-                },
-                {
-                    "$group": {
-                        "_id": "family_group",
-                        "families": {"$addToSet": "$family"},
-                    }
-                },
-            ]
-        )
-    )
+    result = list(conn.aggregate([
+        {"$match": subset_filter},
+        {"$project": {
+            "family": {"$arrayElemAt": ["$data.families", 0]}
+        }},
+        {"$group": {
+            "_id": "family_group",
+            "families": {"$addToSet": "$family"}
+        }}
+    ]))
     if result:
         return set(result[0]["families"])
     return set()
@@ -563,13 +534,11 @@ def get_subset_families(project_name, subset_ids=None):
 
 def get_version_by_id(project_name, version_id, fields=None):
     """Single version entity data by it's id.
-
     Args:
         project_name (str): Name of project where to look for queried entities.
         version_id (Union[str, ObjectId]): Id of version which should be found.
         fields (Iterable[str]): Fields that should be returned. All fields are
             returned if 'None' is passed.
-
     Returns:
         None: If version with specified filters was not found.
         Dict: Version document which can be reduced to specified 'fields'.
@@ -581,7 +550,7 @@ def get_version_by_id(project_name, version_id, fields=None):
 
     query_filter = {
         "type": {"$in": ["version", "hero_version"]},
-        "_id": version_id,
+        "_id": version_id
     }
     conn = get_project_connection(project_name)
     return conn.find_one(query_filter, _prepare_fields(fields))
@@ -589,14 +558,12 @@ def get_version_by_id(project_name, version_id, fields=None):
 
 def get_version_by_name(project_name, version, subset_id, fields=None):
     """Single version entity data by it's name and subset id.
-
     Args:
         project_name (str): Name of project where to look for queried entities.
         version (int): name of version entity (it's version).
         subset_id (Union[str, ObjectId]): Id of version which should be found.
         fields (Iterable[str]): Fields that should be returned. All fields are
             returned if 'None' is passed.
-
     Returns:
         None: If version with specified filters was not found.
         Dict: Version document which can be reduced to specified 'fields'.
@@ -607,23 +574,23 @@ def get_version_by_name(project_name, version, subset_id, fields=None):
         return None
 
     conn = get_project_connection(project_name)
-    query_filter = {"type": "version", "parent": subset_id, "name": version}
+    query_filter = {
+        "type": "version",
+        "parent": subset_id,
+        "name": version
+    }
     return conn.find_one(query_filter, _prepare_fields(fields))
 
 
 def version_is_latest(project_name, version_id):
     """Is version the latest from it's subset.
-
     Note:
         Hero versions are considered as latest.
-
     Todo:
         Maybe raise exception when version was not found?
-
     Args:
         project_name (str):Name of project where to look for queried entities.
         version_id (Union[str, ObjectId]): Version id which is checked.
-
     Returns:
         bool: True if is latest version from subset else False.
     """
@@ -654,7 +621,7 @@ def _get_versions(
     versions=None,
     standard=True,
     hero=False,
-    fields=None,
+    fields=None
 ):
     version_types = []
     if standard:
@@ -703,12 +670,10 @@ def get_versions(
     subset_ids=None,
     versions=None,
     hero=False,
-    fields=None,
+    fields=None
 ):
     """Version entities data from one project filtered by entered filters.
-
     Filters are additive (all conditions must pass to return subset).
-
     Args:
         project_name (str): Name of project where to look for queried entities.
         version_ids (Iterable[Union[str, ObjectId]]): Version ids that will
@@ -720,7 +685,6 @@ def get_versions(
         hero (bool): Look also for hero versions.
         fields (Iterable[str]): Fields that should be returned. All fields are
             returned if 'None' is passed.
-
     Returns:
         Cursor: Iterable cursor yielding all matching versions.
     """
@@ -732,20 +696,18 @@ def get_versions(
         versions,
         standard=True,
         hero=hero,
-        fields=fields,
+        fields=fields
     )
 
 
 def get_hero_version_by_subset_id(project_name, subset_id, fields=None):
     """Hero version by subset id.
-
     Args:
         project_name (str): Name of project where to look for queried entities.
         subset_id (Union[str, ObjectId]): Subset id under which
             is hero version.
         fields (Iterable[str]): Fields that should be returned. All fields are
             returned if 'None' is passed.
-
     Returns:
         None: If hero version for passed subset id does not exists.
         Dict: Hero version entity data.
@@ -755,15 +717,13 @@ def get_hero_version_by_subset_id(project_name, subset_id, fields=None):
     if not subset_id:
         return None
 
-    versions = list(
-        _get_versions(
-            project_name,
-            subset_ids=[subset_id],
-            standard=False,
-            hero=True,
-            fields=fields,
-        )
-    )
+    versions = list(_get_versions(
+        project_name,
+        subset_ids=[subset_id],
+        standard=False,
+        hero=True,
+        fields=fields
+    ))
     if versions:
         return versions[0]
     return None
@@ -771,13 +731,11 @@ def get_hero_version_by_subset_id(project_name, subset_id, fields=None):
 
 def get_hero_version_by_id(project_name, version_id, fields=None):
     """Hero version by it's id.
-
     Args:
         project_name (str): Name of project where to look for queried entities.
         version_id (Union[str, ObjectId]): Hero version id.
         fields (Iterable[str]): Fields that should be returned. All fields are
             returned if 'None' is passed.
-
     Returns:
         None: If hero version with passed id was not found.
         Dict: Hero version entity data.
@@ -787,25 +745,25 @@ def get_hero_version_by_id(project_name, version_id, fields=None):
     if not version_id:
         return None
 
-    versions = list(
-        _get_versions(
-            project_name,
-            version_ids=[version_id],
-            standard=False,
-            hero=True,
-            fields=fields,
-        )
-    )
+    versions = list(_get_versions(
+        project_name,
+        version_ids=[version_id],
+        standard=False,
+        hero=True,
+        fields=fields
+    ))
     if versions:
         return versions[0]
     return None
 
 
 def get_hero_versions(
-    project_name, subset_ids=None, version_ids=None, fields=None
+    project_name,
+    subset_ids=None,
+    version_ids=None,
+    fields=None
 ):
     """Hero version entities data from one project filtered by entered filters.
-
     Args:
         project_name (str): Name of project where to look for queried entities.
         subset_ids (Iterable[Union[str, ObjectId]]): Subset ids for which
@@ -814,7 +772,6 @@ def get_hero_versions(
             ignored if 'None' is passed.
         fields (Iterable[str]): Fields that should be returned. All fields are
             returned if 'None' is passed.
-
     Returns:
         Cursor|list: Iterable yielding hero versions matching passed filters.
     """
@@ -825,24 +782,21 @@ def get_hero_versions(
         version_ids,
         standard=False,
         hero=True,
-        fields=fields,
+        fields=fields
     )
 
 
 def get_output_link_versions(project_name, version_id, fields=None):
     """Versions where passed version was used as input.
-
     Question:
         Not 100% sure about the usage of the function so the name and docstring
             maybe does not match what it does?
-
     Args:
         project_name (str): Name of project where to look for queried entities.
         version_id (Union[str, ObjectId]): Version id which can be used
             as input link for other versions.
         fields (Iterable[str]): Fields that should be returned. All fields are
             returned if 'None' is passed.
-
     Returns:
         Iterable: Iterable cursor yielding versions that are used as input
             links for passed version.
@@ -854,19 +808,20 @@ def get_output_link_versions(project_name, version_id, fields=None):
 
     conn = get_project_connection(project_name)
     # Does make sense to look for hero versions?
-    query_filter = {"type": "version", "data.inputLinks.id": version_id}
+    query_filter = {
+        "type": "version",
+        "data.inputLinks.id": version_id
+    }
     return conn.find(query_filter, _prepare_fields(fields))
 
 
 def get_last_versions(project_name, subset_ids, fields=None):
     """Latest versions for entered subset_ids.
-
     Args:
         project_name (str): Name of project where to look for queried entities.
         subset_ids (Iterable[Union[str, ObjectId]]): List of subset ids.
         fields (Iterable[str]): Fields that should be returned. All fields are
             returned if 'None' is passed.
-
     Returns:
         dict[ObjectId, int]: Key is subset id and value is last version name.
     """
@@ -894,18 +849,24 @@ def get_last_versions(project_name, subset_ids, fields=None):
                 fields_s.remove(field)
         limit_query = len(fields_s) == 0
 
-    group_item = {"_id": "$parent", "_version_id": {"$last": "$_id"}}
+    group_item = {
+        "_id": "$parent",
+        "_version_id": {"$last": "$_id"}
+    }
     # Add name if name is needed (only for limit query)
     if name_needed:
         group_item["name"] = {"$last": "$name"}
 
     aggregation_pipeline = [
         # Find all versions of those subsets
-        {"$match": {"type": "version", "parent": {"$in": subset_ids}}},
+        {"$match": {
+            "type": "version",
+            "parent": {"$in": subset_ids}
+        }},
         # Sorting versions all together
         {"$sort": {"name": 1}},
         # Group them by "parent", but only take the last
-        {"$group": group_item},
+        {"$group": group_item}
     ]
 
     conn = get_project_connection(project_name)
@@ -920,7 +881,10 @@ def get_last_versions(project_name, subset_ids, fields=None):
             output[subset_id] = item_data
         return output
 
-    version_ids = [doc["_version_id"] for doc in aggregate_result]
+    version_ids = [
+        doc["_version_id"]
+        for doc in aggregate_result
+    ]
 
     fields = _prepare_fields(fields, ["parent"])
 
@@ -928,18 +892,19 @@ def get_last_versions(project_name, subset_ids, fields=None):
         project_name, version_ids=version_ids, fields=fields
     )
 
-    return {version_doc["parent"]: version_doc for version_doc in version_docs}
+    return {
+        version_doc["parent"]: version_doc
+        for version_doc in version_docs
+    }
 
 
 def get_last_version_by_subset_id(project_name, subset_id, fields=None):
     """Last version for passed subset id.
-
     Args:
         project_name (str): Name of project where to look for queried entities.
         subset_id (Union[str, ObjectId]): Id of version which should be found.
         fields (Iterable[str]): Fields that should be returned. All fields are
             returned if 'None' is passed.
-
     Returns:
         None: If version with specified filters was not found.
         Dict: Version document which can be reduced to specified 'fields'.
@@ -959,10 +924,8 @@ def get_last_version_by_subset_name(
     project_name, subset_name, asset_id=None, asset_name=None, fields=None
 ):
     """Last version for passed subset name under asset id/name.
-
     It is required to pass 'asset_id' or 'asset_name'. Asset id is recommended
     if is available.
-
     Args:
         project_name (str): Name of project where to look for queried entities.
         subset_name (str): Name of subset.
@@ -971,7 +934,6 @@ def get_last_version_by_subset_name(
         asset_name (str): Asset name which is parent of passed subset name.
         fields (Iterable[str]): Fields that should be returned. All fields are
             returned if 'None' is passed.
-
     Returns:
         None: If version with specified filters was not found.
         Dict: Version document which can be reduced to specified 'fields'.
@@ -997,13 +959,11 @@ def get_last_version_by_subset_name(
 
 def get_representation_by_id(project_name, representation_id, fields=None):
     """Representation entity data by it's id.
-
     Args:
         project_name (str): Name of project where to look for queried entities.
         representation_id (Union[str, ObjectId]): Representation id.
         fields (Iterable[str]): Fields that should be returned. All fields are
             returned if 'None' is passed.
-
     Returns:
         None: If representation with specified filters was not found.
         Dict: Representation entity data which can be reduced
@@ -1014,7 +974,9 @@ def get_representation_by_id(project_name, representation_id, fields=None):
         return None
 
     repre_types = ["representation", "archived_representation"]
-    query_filter = {"type": {"$in": repre_types}}
+    query_filter = {
+        "type": {"$in": repre_types}
+    }
     if representation_id is not None:
         query_filter["_id"] = convert_id(representation_id)
 
@@ -1027,14 +989,12 @@ def get_representation_by_name(
     project_name, representation_name, version_id, fields=None
 ):
     """Representation entity data by it's name and it's version id.
-
     Args:
         project_name (str): Name of project where to look for queried entities.
         representation_name (str): Representation name.
         version_id (Union[str, ObjectId]): Id of parent version entity.
         fields (Iterable[str]): Fields that should be returned. All fields are
             returned if 'None' is passed.
-
     Returns:
         None: If representation with specified filters was not found.
         Dict: Representation entity data which can be reduced
@@ -1048,11 +1008,36 @@ def get_representation_by_name(
     query_filter = {
         "type": {"$in": repre_types},
         "name": representation_name,
-        "parent": version_id,
+        "parent": version_id
     }
 
     conn = get_project_connection(project_name)
     return conn.find_one(query_filter, _prepare_fields(fields))
+	
+	
+def get_representation_with_task(
+    project_name: str, task_name: str, version_doc: dict
+) -> str:
+    """Returns representation for given project and task, and version.
+
+    Args:
+        project_name (str): Project name.
+        task_name (str): Task name.
+        version_doc (dict): Version doc.
+
+    Returns:
+        str: Representation.
+    """
+    return next(
+        (
+            representation
+            for representation in get_representations(
+                project_name, version_ids=[version_doc["_id"]]
+            )
+            if representation["context"]["task"]["name"] == task_name
+        ),
+        None,
+    )
 
 
 def _flatten_dict(data):
@@ -1107,31 +1092,6 @@ def _regex_filters(filters):
     return output
 
 
-def get_representation(
-    project_name: str, task_name: str, version_doc: dict
-) -> str:
-    """Returns representation for given project and task, and version.
-
-    Args:
-        project_name (str): Project name.
-        task_name (str): Task name.
-        version_doc (dict): Version doc.
-
-    Returns:
-        str: Representation.
-    """
-    return next(
-        (
-            representation
-            for representation in get_representations(
-                project_name, version_ids=[version_doc["_id"]]
-            )
-            if representation["context"]["task"]["name"] == task_name
-        ),
-        None,
-    )
-
-
 def _get_representations(
     project_name,
     representation_ids,
@@ -1141,7 +1101,7 @@ def _get_representations(
     names_by_version_ids,
     standard,
     archived,
-    fields,
+    fields
 ):
     default_output = []
     repre_types = []
@@ -1180,12 +1140,10 @@ def _get_representations(
         or_query = []
         for version_id, names in names_by_version_ids.items():
             if version_id and names:
-                or_query.append(
-                    {
-                        "parent": convert_id(version_id),
-                        "name": {"$in": list(names)},
-                    }
-                )
+                or_query.append({
+                    "parent": convert_id(version_id),
+                    "name": {"$in": list(names)}
+                })
         if not or_query:
             return default_output
         or_queries.append(or_query)
@@ -1232,12 +1190,10 @@ def get_representations(
     names_by_version_ids=None,
     archived=False,
     standard=True,
-    fields=None,
+    fields=None
 ):
     """Representaion entities data from one project filtered by filters.
-
     Filters are additive (all conditions must pass to return subset).
-
     Args:
         project_name (str): Name of project where to look for queried entities.
         representation_ids (Iterable[Union[str, ObjectId]]): Representation ids
@@ -1253,7 +1209,6 @@ def get_representations(
         archived (bool): Output will also contain archived representations.
         fields (Iterable[str]): Fields that should be returned. All fields are
             returned if 'None' is passed.
-
     Returns:
         Cursor: Iterable cursor yielding all matching representations.
     """
@@ -1267,7 +1222,7 @@ def get_representations(
         names_by_version_ids=names_by_version_ids,
         standard=True,
         archived=archived,
-        fields=fields,
+        fields=fields
     )
 
 
@@ -1278,12 +1233,10 @@ def get_archived_representations(
     version_ids=None,
     context_filters=None,
     names_by_version_ids=None,
-    fields=None,
+    fields=None
 ):
     """Archived representaion entities data from project with applied filters.
-
     Filters are additive (all conditions must pass to return subset).
-
     Args:
         project_name (str): Name of project where to look for queried entities.
         representation_ids (Iterable[Union[str, ObjectId]]): Representation ids
@@ -1298,7 +1251,6 @@ def get_archived_representations(
             using version ids and list of names under the version.
         fields (Iterable[str]): Fields that should be returned. All fields are
             returned if 'None' is passed.
-
     Returns:
         Cursor: Iterable cursor yielding all matching representations.
     """
@@ -1312,21 +1264,18 @@ def get_archived_representations(
         names_by_version_ids=names_by_version_ids,
         standard=False,
         archived=True,
-        fields=fields,
+        fields=fields
     )
 
 
 def get_representations_parents(project_name, representations):
     """Prepare parents of representation entities.
-
     Each item of returned dictionary contains version, subset, asset
     and project in that order.
-
     Args:
         project_name (str): Name of project where to look for queried entities.
         representations (List[dict]): Representation entities with at least
             '_id' and 'parent' keys.
-
     Returns:
         dict[ObjectId, tuple]: Parents by representation id.
     """
@@ -1344,7 +1293,9 @@ def get_representations_parents(project_name, representations):
         repre_docs_by_version_id[version_id].append(repre_doc)
 
     version_docs = get_versions(
-        project_name, version_ids=repre_docs_by_version_id.keys(), hero=True
+        project_name,
+        version_ids=repre_docs_by_version_id.keys(),
+        hero=True
     )
     for version_doc in version_docs:
         version_id = version_doc["_id"]
@@ -1365,7 +1316,8 @@ def get_representations_parents(project_name, representations):
         project_name, asset_ids=subset_docs_by_asset_id.keys()
     )
     asset_docs_by_id = {
-        asset_doc["_id"]: asset_doc for asset_doc in asset_docs
+        asset_doc["_id"]: asset_doc
+        for asset_doc in asset_docs
     }
 
     project_doc = get_project(project_name)
@@ -1384,25 +1336,19 @@ def get_representations_parents(project_name, representations):
         for repre_doc in repre_docs:
             repre_id = repre_doc["_id"]
             output[repre_id] = (
-                version_doc,
-                subset_doc,
-                asset_doc,
-                project_doc,
+                version_doc, subset_doc, asset_doc, project_doc
             )
     return output
 
 
 def get_representation_parents(project_name, representation):
     """Prepare parents of representation entity.
-
     Each item of returned dictionary contains version, subset, asset
     and project in that order.
-
     Args:
         project_name (str): Name of project where to look for queried entities.
         representation (dict): Representation entities with at least
             '_id' and 'parent' keys.
-
     Returns:
         dict[ObjectId, tuple]: Parents by representation id.
     """
@@ -1419,12 +1365,10 @@ def get_representation_parents(project_name, representation):
 
 def get_thumbnail_id_from_source(project_name, src_type, src_id):
     """Receive thumbnail id from source entity.
-
     Args:
         project_name (str): Name of project where to look for queried entities.
         src_type (str): Type of source entity ('asset', 'version').
         src_id (Union[str, ObjectId]): Id of source entity.
-
     Returns:
         ObjectId: Thumbnail id assigned to entity.
         None: If Source entity does not have any thumbnail id assigned.
@@ -1444,17 +1388,14 @@ def get_thumbnail_id_from_source(project_name, src_type, src_id):
 
 def get_thumbnails(project_name, thumbnail_ids, fields=None):
     """Receive thumbnails entity data.
-
     Thumbnail entity can be used to receive binary content of thumbnail based
     on it's content and ThumbnailResolvers.
-
     Args:
         project_name (str): Name of project where to look for queried entities.
         thumbnail_ids (Iterable[Union[str, ObjectId]]): Ids of thumbnail
             entities.
         fields (Iterable[str]): Fields that should be returned. All fields are
             returned if 'None' is passed.
-
     Returns:
         cursor: Cursor of queried documents.
     """
@@ -1464,20 +1405,21 @@ def get_thumbnails(project_name, thumbnail_ids, fields=None):
 
     if not thumbnail_ids:
         return []
-    query_filter = {"type": "thumbnail", "_id": {"$in": thumbnail_ids}}
+    query_filter = {
+        "type": "thumbnail",
+        "_id": {"$in": thumbnail_ids}
+    }
     conn = get_project_connection(project_name)
     return conn.find(query_filter, _prepare_fields(fields))
 
 
 def get_thumbnail(project_name, thumbnail_id, fields=None):
     """Receive thumbnail entity data.
-
     Args:
         project_name (str): Name of project where to look for queried entities.
         thumbnail_id (Union[str, ObjectId]): Id of thumbnail entity.
         fields (Iterable[str]): Fields that should be returned. All fields are
             returned if 'None' is passed.
-
     Returns:
         None: If thumbnail with specified id was not found.
         Dict: Thumbnail entity data which can be reduced to specified 'fields'.
@@ -1494,12 +1436,10 @@ def get_workfile_info(
     project_name, asset_id, task_name, filename, fields=None
 ):
     """Document with workfile information.
-
     Warning:
         Query is based on filename and context which does not meant it will
         find always right and expected result. Information have limited usage
         and is not recommended to use it as source information about workfile.
-
     Args:
         project_name (str): Name of project where to look for queried entities.
         asset_id (Union[str, ObjectId]): Id of asset entity.
@@ -1515,7 +1455,7 @@ def get_workfile_info(
         "type": "workfile",
         "parent": convert_id(asset_id),
         "task_name": task_name,
-        "filename": filename,
+        "filename": filename
     }
     conn = get_project_connection(project_name)
     return conn.find_one(query_filter, _prepare_fields(fields))
@@ -1530,14 +1470,12 @@ def get_workfile_info(
 - Maya - Shaders
     - openpype/hosts/maya/api/shader_definition_editor.py
     - openpype/hosts/maya/plugins/publish/validate_model_name.py
-
 ## Global publish plugins
 - openpype/plugins/publish/extract_hierarchy_avalon.py
     Create:
     - asset
     Update:
     - asset
-
 ## Lib
 - openpype/lib/avalon_context.py
     Update:

--- a/openpype/client/entities.py
+++ b/openpype/client/entities.py
@@ -521,17 +521,19 @@ def get_subset_families(project_name, subset_ids=None):
 def match_subset_id(
     project_name: str, task_name: str, family: str, asset_doc: dict
 ) -> str:
-    """Returns subset ID for given project, task and family.
+    """Match subset ID for given project, task and family.
+
     Args:
         project_name (str): Project_name.
         task_name (str): Task name.
         family (str): Family.
         asset_doc (dict): Asset doc.
+
     Returns:
         str: Subset ID.
     """
 
-    # Getting subsets of the correct family
+    # Get subsets of the correct family
     filtered_subsets = [
         subset
         for subset in get_subsets(
@@ -553,16 +555,14 @@ def match_subset_id(
         )
         return
 
-    # Matching subset which has task name in its name
+    # Match subset which has `task_name` in its name
     subset_id = None
     low_task_name = task_name.lower()
     if len(filtered_subsets) > 1:
         for subset in filtered_subsets:
             if low_task_name in subset["name"].lower():
                 subset_id = subset["_id"]
-                break
-
-    return subset_id
+                return subset_id
 
 
 def get_version_by_id(project_name, version_id, fields=None):
@@ -1082,11 +1082,13 @@ def get_representation_by_name(
 def get_representation_by_task(
     project_name: str, task_name: str, version_doc: dict
 ) -> str:
-    """Returns representation for given project and task, and version.
+    """Return representation for given project and task, and version.
+
     Args:
         project_name (str): Project name.
         task_name (str): Task name.
         version_doc (dict): Version doc.
+
     Returns:
         str: Representation.
     """

--- a/openpype/client/entities.py
+++ b/openpype/client/entities.py
@@ -1,6 +1,8 @@
 """Unclear if these will have public functions like these.
+
 Goal is that most of functions here are called on (or with) an object
 that has project name as a context (e.g. on 'ProjectEntity'?).
+
 + We will need more specific functions doing wery specific queires really fast.
 """
 
@@ -34,9 +36,11 @@ def _prepare_fields(fields, required_fields=None):
 
 def convert_id(in_id):
     """Helper function for conversion of id from string to ObjectId.
+
     Args:
         in_id (Union[str, ObjectId, Any]): Entity id that should be converted
             to right type for queries.
+
     Returns:
         Union[ObjectId, Any]: Converted ids to ObjectId or in type.
     """
@@ -48,9 +52,11 @@ def convert_id(in_id):
 
 def convert_ids(in_ids):
     """Helper function for conversion of ids from string to ObjectId.
+
     Args:
         in_ids (Iterable[Union[str, ObjectId, Any]]): List of entity ids that
             should be converted to right type for queries.
+
     Returns:
         List[ObjectId]: Converted ids to ObjectId.
     """
@@ -104,8 +110,10 @@ def get_project(project_name, active=True, inactive=True, fields=None):
 
 def get_whole_project(project_name):
     """Receive all documents from project.
+
     Helper that can be used to get all document from whole project. For example
     for backups etc.
+
     Returns:
         Cursor: Query cursor as iterable which returns all documents from
             project collection.
@@ -117,11 +125,13 @@ def get_whole_project(project_name):
 
 def get_asset_by_id(project_name, asset_id, fields=None):
     """Receive asset data by it's id.
+
     Args:
         project_name (str): Name of project where to look for queried entities.
         asset_id (Union[str, ObjectId]): Asset's id.
         fields (Iterable[str]): Fields that should be returned. All fields are
             returned if 'None' is passed.
+
     Returns:
         dict: Asset entity data.
         None: Asset was not found by id.
@@ -138,11 +148,13 @@ def get_asset_by_id(project_name, asset_id, fields=None):
 
 def get_asset_by_name(project_name, asset_name, fields=None):
     """Receive asset data by it's name.
+
     Args:
         project_name (str): Name of project where to look for queried entities.
         asset_name (str): Asset's name.
         fields (Iterable[str]): Fields that should be returned. All fields are
             returned if 'None' is passed.
+
     Returns:
         dict: Asset entity data.
         None: Asset was not found by name.
@@ -169,9 +181,12 @@ def _get_assets(
     fields=None
 ):
     """Assets for specified project by passed filters.
+
     Passed filters (ids and names) are always combined so all conditions must
     match.
+
     To receive all assets from project just keep filters empty.
+
     Args:
         project_name (str): Name of project where to look for queried entities.
         asset_ids (Iterable[Union[str, ObjectId]]): Asset ids that should
@@ -182,6 +197,7 @@ def _get_assets(
         archived (bool): Query archived assets (type 'archived_asset').
         fields (Iterable[str]): Fields that should be returned. All fields are
             returned if 'None' is passed.
+
     Returns:
         Cursor: Query cursor as iterable which returns asset documents matching
             passed filters.
@@ -232,9 +248,12 @@ def get_assets(
     fields=None
 ):
     """Assets for specified project by passed filters.
+
     Passed filters (ids and names) are always combined so all conditions must
     match.
+
     To receive all assets from project just keep filters empty.
+
     Args:
         project_name (str): Name of project where to look for queried entities.
         asset_ids (Iterable[Union[str, ObjectId]]): Asset ids that should
@@ -244,6 +263,7 @@ def get_assets(
         archived (bool): Add also archived assets.
         fields (Iterable[str]): Fields that should be returned. All fields are
             returned if 'None' is passed.
+
     Returns:
         Cursor: Query cursor as iterable which returns asset documents matching
             passed filters.
@@ -268,9 +288,12 @@ def get_archived_assets(
     fields=None
 ):
     """Archived assets for specified project by passed filters.
+
     Passed filters (ids and names) are always combined so all conditions must
     match.
+
     To receive all archived assets from project just keep filters empty.
+
     Args:
         project_name (str): Name of project where to look for queried entities.
         asset_ids (Iterable[Union[str, ObjectId]]): Asset ids that should
@@ -279,6 +302,7 @@ def get_archived_assets(
         parent_ids (Iterable[Union[str, ObjectId]]): Parent asset ids.
         fields (Iterable[str]): Fields that should be returned. All fields are
             returned if 'None' is passed.
+
     Returns:
         Cursor: Query cursor as iterable which returns asset documents matching
             passed filters.
@@ -291,10 +315,12 @@ def get_archived_assets(
 
 def get_asset_ids_with_subsets(project_name, asset_ids=None):
     """Find out which assets have existing subsets.
+
     Args:
         project_name (str): Name of project where to look for queried entities.
         asset_ids (Iterable[Union[str, ObjectId]]): Look only for entered
             asset ids.
+
     Returns:
         Iterable[ObjectId]: Asset ids that have existing subsets.
     """
@@ -331,11 +357,13 @@ def get_asset_ids_with_subsets(project_name, asset_ids=None):
 
 def get_subset_by_id(project_name, subset_id, fields=None):
     """Single subset entity data by it's id.
+
     Args:
         project_name (str): Name of project where to look for queried entities.
         subset_id (Union[str, ObjectId]): Id of subset which should be found.
         fields (Iterable[str]): Fields that should be returned. All fields are
             returned if 'None' is passed.
+
     Returns:
         None: If subset with specified filters was not found.
         Dict: Subset document which can be reduced to specified 'fields'.
@@ -352,12 +380,14 @@ def get_subset_by_id(project_name, subset_id, fields=None):
 
 def get_subset_by_name(project_name, subset_name, asset_id, fields=None):
     """Single subset entity data by it's name and it's version id.
+
     Args:
         project_name (str): Name of project where to look for queried entities.
         subset_name (str): Name of subset.
         asset_id (Union[str, ObjectId]): Id of parent asset.
         fields (Iterable[str]): Fields that should be returned. All fields are
             returned if 'None' is passed.
+
     Returns:
         None: If subset with specified filters was not found.
         Dict: Subset document which can be reduced to specified 'fields'.
@@ -389,7 +419,9 @@ def get_subsets(
     fields=None
 ):
     """Subset entities data from one project filtered by entered filters.
+
     Filters are additive (all conditions must pass to return subset).
+
     Args:
         project_name (str): Name of project where to look for queried entities.
         subset_ids (Iterable[Union[str, ObjectId]]): Subset ids that should be
@@ -403,6 +435,7 @@ def get_subsets(
         archived (bool): Look for archived subsets too.
         fields (Iterable[str]): Fields that should be returned. All fields are
             returned if 'None' is passed.
+
     Returns:
         Cursor: Iterable cursor yielding all matching subsets.
     """
@@ -447,19 +480,53 @@ def get_subsets(
 
     conn = get_project_connection(project_name)
     return conn.find(query_filter, _prepare_fields(fields))
-	
+
+
+def get_subset_families(project_name, subset_ids=None):
+    """Set of main families of subsets.
+
+    Args:
+        project_name (str): Name of project where to look for queried entities.
+        subset_ids (Iterable[Union[str, ObjectId]]): Subset ids that should
+            be queried. All subsets from project are used if 'None' is passed.
+
+    Returns:
+         set[str]: Main families of matching subsets.
+    """
+
+    subset_filter = {
+        "type": "subset"
+    }
+    if subset_ids is not None:
+        if not subset_ids:
+            return set()
+        subset_filter["_id"] = {"$in": list(subset_ids)}
+
+    conn = get_project_connection(project_name)
+    result = list(conn.aggregate([
+        {"$match": subset_filter},
+        {"$project": {
+            "family": {"$arrayElemAt": ["$data.families", 0]}
+        }},
+        {"$group": {
+            "_id": "family_group",
+            "families": {"$addToSet": "$family"}
+        }}
+    ]))
+    if result:
+        return set(result[0]["families"])
+    return set()
+
 
 def match_subset_id(
     project_name: str, task_name: str, family: str, asset_doc: dict
 ) -> str:
     """Returns subset ID for given project, task and family.
-
     Args:
         project_name (str): Project_name.
         task_name (str): Task name.
         family (str): Family.
         asset_doc (dict): Asset doc.
-
     Returns:
         str: Subset ID.
     """
@@ -498,47 +565,15 @@ def match_subset_id(
     return subset_id
 
 
-def get_subset_families(project_name, subset_ids=None):
-    """Set of main families of subsets.
-    Args:
-        project_name (str): Name of project where to look for queried entities.
-        subset_ids (Iterable[Union[str, ObjectId]]): Subset ids that should
-            be queried. All subsets from project are used if 'None' is passed.
-    Returns:
-         set[str]: Main families of matching subsets.
-    """
-
-    subset_filter = {
-        "type": "subset"
-    }
-    if subset_ids is not None:
-        if not subset_ids:
-            return set()
-        subset_filter["_id"] = {"$in": list(subset_ids)}
-
-    conn = get_project_connection(project_name)
-    result = list(conn.aggregate([
-        {"$match": subset_filter},
-        {"$project": {
-            "family": {"$arrayElemAt": ["$data.families", 0]}
-        }},
-        {"$group": {
-            "_id": "family_group",
-            "families": {"$addToSet": "$family"}
-        }}
-    ]))
-    if result:
-        return set(result[0]["families"])
-    return set()
-
-
 def get_version_by_id(project_name, version_id, fields=None):
     """Single version entity data by it's id.
+
     Args:
         project_name (str): Name of project where to look for queried entities.
         version_id (Union[str, ObjectId]): Id of version which should be found.
         fields (Iterable[str]): Fields that should be returned. All fields are
             returned if 'None' is passed.
+
     Returns:
         None: If version with specified filters was not found.
         Dict: Version document which can be reduced to specified 'fields'.
@@ -558,12 +593,14 @@ def get_version_by_id(project_name, version_id, fields=None):
 
 def get_version_by_name(project_name, version, subset_id, fields=None):
     """Single version entity data by it's name and subset id.
+
     Args:
         project_name (str): Name of project where to look for queried entities.
         version (int): name of version entity (it's version).
         subset_id (Union[str, ObjectId]): Id of version which should be found.
         fields (Iterable[str]): Fields that should be returned. All fields are
             returned if 'None' is passed.
+
     Returns:
         None: If version with specified filters was not found.
         Dict: Version document which can be reduced to specified 'fields'.
@@ -584,13 +621,17 @@ def get_version_by_name(project_name, version, subset_id, fields=None):
 
 def version_is_latest(project_name, version_id):
     """Is version the latest from it's subset.
+
     Note:
         Hero versions are considered as latest.
+
     Todo:
         Maybe raise exception when version was not found?
+
     Args:
         project_name (str):Name of project where to look for queried entities.
         version_id (Union[str, ObjectId]): Version id which is checked.
+
     Returns:
         bool: True if is latest version from subset else False.
     """
@@ -673,7 +714,9 @@ def get_versions(
     fields=None
 ):
     """Version entities data from one project filtered by entered filters.
+
     Filters are additive (all conditions must pass to return subset).
+
     Args:
         project_name (str): Name of project where to look for queried entities.
         version_ids (Iterable[Union[str, ObjectId]]): Version ids that will
@@ -685,6 +728,7 @@ def get_versions(
         hero (bool): Look also for hero versions.
         fields (Iterable[str]): Fields that should be returned. All fields are
             returned if 'None' is passed.
+
     Returns:
         Cursor: Iterable cursor yielding all matching versions.
     """
@@ -702,12 +746,14 @@ def get_versions(
 
 def get_hero_version_by_subset_id(project_name, subset_id, fields=None):
     """Hero version by subset id.
+
     Args:
         project_name (str): Name of project where to look for queried entities.
         subset_id (Union[str, ObjectId]): Subset id under which
             is hero version.
         fields (Iterable[str]): Fields that should be returned. All fields are
             returned if 'None' is passed.
+
     Returns:
         None: If hero version for passed subset id does not exists.
         Dict: Hero version entity data.
@@ -731,11 +777,13 @@ def get_hero_version_by_subset_id(project_name, subset_id, fields=None):
 
 def get_hero_version_by_id(project_name, version_id, fields=None):
     """Hero version by it's id.
+
     Args:
         project_name (str): Name of project where to look for queried entities.
         version_id (Union[str, ObjectId]): Hero version id.
         fields (Iterable[str]): Fields that should be returned. All fields are
             returned if 'None' is passed.
+
     Returns:
         None: If hero version with passed id was not found.
         Dict: Hero version entity data.
@@ -764,6 +812,7 @@ def get_hero_versions(
     fields=None
 ):
     """Hero version entities data from one project filtered by entered filters.
+
     Args:
         project_name (str): Name of project where to look for queried entities.
         subset_ids (Iterable[Union[str, ObjectId]]): Subset ids for which
@@ -772,6 +821,7 @@ def get_hero_versions(
             ignored if 'None' is passed.
         fields (Iterable[str]): Fields that should be returned. All fields are
             returned if 'None' is passed.
+
     Returns:
         Cursor|list: Iterable yielding hero versions matching passed filters.
     """
@@ -788,15 +838,18 @@ def get_hero_versions(
 
 def get_output_link_versions(project_name, version_id, fields=None):
     """Versions where passed version was used as input.
+
     Question:
         Not 100% sure about the usage of the function so the name and docstring
             maybe does not match what it does?
+
     Args:
         project_name (str): Name of project where to look for queried entities.
         version_id (Union[str, ObjectId]): Version id which can be used
             as input link for other versions.
         fields (Iterable[str]): Fields that should be returned. All fields are
             returned if 'None' is passed.
+
     Returns:
         Iterable: Iterable cursor yielding versions that are used as input
             links for passed version.
@@ -817,11 +870,13 @@ def get_output_link_versions(project_name, version_id, fields=None):
 
 def get_last_versions(project_name, subset_ids, fields=None):
     """Latest versions for entered subset_ids.
+
     Args:
         project_name (str): Name of project where to look for queried entities.
         subset_ids (Iterable[Union[str, ObjectId]]): List of subset ids.
         fields (Iterable[str]): Fields that should be returned. All fields are
             returned if 'None' is passed.
+
     Returns:
         dict[ObjectId, int]: Key is subset id and value is last version name.
     """
@@ -900,11 +955,13 @@ def get_last_versions(project_name, subset_ids, fields=None):
 
 def get_last_version_by_subset_id(project_name, subset_id, fields=None):
     """Last version for passed subset id.
+
     Args:
         project_name (str): Name of project where to look for queried entities.
         subset_id (Union[str, ObjectId]): Id of version which should be found.
         fields (Iterable[str]): Fields that should be returned. All fields are
             returned if 'None' is passed.
+
     Returns:
         None: If version with specified filters was not found.
         Dict: Version document which can be reduced to specified 'fields'.
@@ -924,8 +981,10 @@ def get_last_version_by_subset_name(
     project_name, subset_name, asset_id=None, asset_name=None, fields=None
 ):
     """Last version for passed subset name under asset id/name.
+
     It is required to pass 'asset_id' or 'asset_name'. Asset id is recommended
     if is available.
+
     Args:
         project_name (str): Name of project where to look for queried entities.
         subset_name (str): Name of subset.
@@ -934,6 +993,7 @@ def get_last_version_by_subset_name(
         asset_name (str): Asset name which is parent of passed subset name.
         fields (Iterable[str]): Fields that should be returned. All fields are
             returned if 'None' is passed.
+
     Returns:
         None: If version with specified filters was not found.
         Dict: Version document which can be reduced to specified 'fields'.
@@ -959,11 +1019,13 @@ def get_last_version_by_subset_name(
 
 def get_representation_by_id(project_name, representation_id, fields=None):
     """Representation entity data by it's id.
+
     Args:
         project_name (str): Name of project where to look for queried entities.
         representation_id (Union[str, ObjectId]): Representation id.
         fields (Iterable[str]): Fields that should be returned. All fields are
             returned if 'None' is passed.
+
     Returns:
         None: If representation with specified filters was not found.
         Dict: Representation entity data which can be reduced
@@ -989,12 +1051,14 @@ def get_representation_by_name(
     project_name, representation_name, version_id, fields=None
 ):
     """Representation entity data by it's name and it's version id.
+
     Args:
         project_name (str): Name of project where to look for queried entities.
         representation_name (str): Representation name.
         version_id (Union[str, ObjectId]): Id of parent version entity.
         fields (Iterable[str]): Fields that should be returned. All fields are
             returned if 'None' is passed.
+
     Returns:
         None: If representation with specified filters was not found.
         Dict: Representation entity data which can be reduced
@@ -1013,18 +1077,16 @@ def get_representation_by_name(
 
     conn = get_project_connection(project_name)
     return conn.find_one(query_filter, _prepare_fields(fields))
-	
-	
-def get_representation_with_task(
+
+
+def get_representation_by_task(
     project_name: str, task_name: str, version_doc: dict
 ) -> str:
     """Returns representation for given project and task, and version.
-
     Args:
         project_name (str): Project name.
         task_name (str): Task name.
         version_doc (dict): Version doc.
-
     Returns:
         str: Representation.
     """
@@ -1193,7 +1255,9 @@ def get_representations(
     fields=None
 ):
     """Representaion entities data from one project filtered by filters.
+
     Filters are additive (all conditions must pass to return subset).
+
     Args:
         project_name (str): Name of project where to look for queried entities.
         representation_ids (Iterable[Union[str, ObjectId]]): Representation ids
@@ -1209,6 +1273,7 @@ def get_representations(
         archived (bool): Output will also contain archived representations.
         fields (Iterable[str]): Fields that should be returned. All fields are
             returned if 'None' is passed.
+
     Returns:
         Cursor: Iterable cursor yielding all matching representations.
     """
@@ -1236,7 +1301,9 @@ def get_archived_representations(
     fields=None
 ):
     """Archived representaion entities data from project with applied filters.
+
     Filters are additive (all conditions must pass to return subset).
+
     Args:
         project_name (str): Name of project where to look for queried entities.
         representation_ids (Iterable[Union[str, ObjectId]]): Representation ids
@@ -1251,6 +1318,7 @@ def get_archived_representations(
             using version ids and list of names under the version.
         fields (Iterable[str]): Fields that should be returned. All fields are
             returned if 'None' is passed.
+
     Returns:
         Cursor: Iterable cursor yielding all matching representations.
     """
@@ -1270,12 +1338,15 @@ def get_archived_representations(
 
 def get_representations_parents(project_name, representations):
     """Prepare parents of representation entities.
+
     Each item of returned dictionary contains version, subset, asset
     and project in that order.
+
     Args:
         project_name (str): Name of project where to look for queried entities.
         representations (List[dict]): Representation entities with at least
             '_id' and 'parent' keys.
+
     Returns:
         dict[ObjectId, tuple]: Parents by representation id.
     """
@@ -1343,12 +1414,15 @@ def get_representations_parents(project_name, representations):
 
 def get_representation_parents(project_name, representation):
     """Prepare parents of representation entity.
+
     Each item of returned dictionary contains version, subset, asset
     and project in that order.
+
     Args:
         project_name (str): Name of project where to look for queried entities.
         representation (dict): Representation entities with at least
             '_id' and 'parent' keys.
+
     Returns:
         dict[ObjectId, tuple]: Parents by representation id.
     """
@@ -1365,10 +1439,12 @@ def get_representation_parents(project_name, representation):
 
 def get_thumbnail_id_from_source(project_name, src_type, src_id):
     """Receive thumbnail id from source entity.
+
     Args:
         project_name (str): Name of project where to look for queried entities.
         src_type (str): Type of source entity ('asset', 'version').
         src_id (Union[str, ObjectId]): Id of source entity.
+
     Returns:
         ObjectId: Thumbnail id assigned to entity.
         None: If Source entity does not have any thumbnail id assigned.
@@ -1388,14 +1464,17 @@ def get_thumbnail_id_from_source(project_name, src_type, src_id):
 
 def get_thumbnails(project_name, thumbnail_ids, fields=None):
     """Receive thumbnails entity data.
+
     Thumbnail entity can be used to receive binary content of thumbnail based
     on it's content and ThumbnailResolvers.
+
     Args:
         project_name (str): Name of project where to look for queried entities.
         thumbnail_ids (Iterable[Union[str, ObjectId]]): Ids of thumbnail
             entities.
         fields (Iterable[str]): Fields that should be returned. All fields are
             returned if 'None' is passed.
+
     Returns:
         cursor: Cursor of queried documents.
     """
@@ -1415,11 +1494,13 @@ def get_thumbnails(project_name, thumbnail_ids, fields=None):
 
 def get_thumbnail(project_name, thumbnail_id, fields=None):
     """Receive thumbnail entity data.
+
     Args:
         project_name (str): Name of project where to look for queried entities.
         thumbnail_id (Union[str, ObjectId]): Id of thumbnail entity.
         fields (Iterable[str]): Fields that should be returned. All fields are
             returned if 'None' is passed.
+
     Returns:
         None: If thumbnail with specified id was not found.
         Dict: Thumbnail entity data which can be reduced to specified 'fields'.
@@ -1436,10 +1517,12 @@ def get_workfile_info(
     project_name, asset_id, task_name, filename, fields=None
 ):
     """Document with workfile information.
+
     Warning:
         Query is based on filename and context which does not meant it will
         find always right and expected result. Information have limited usage
         and is not recommended to use it as source information about workfile.
+
     Args:
         project_name (str): Name of project where to look for queried entities.
         asset_id (Union[str, ObjectId]): Id of asset entity.
@@ -1470,12 +1553,14 @@ def get_workfile_info(
 - Maya - Shaders
     - openpype/hosts/maya/api/shader_definition_editor.py
     - openpype/hosts/maya/plugins/publish/validate_model_name.py
+
 ## Global publish plugins
 - openpype/plugins/publish/extract_hierarchy_avalon.py
     Create:
     - asset
     Update:
     - asset
+
 ## Lib
 - openpype/lib/avalon_context.py
     Update:

--- a/openpype/hooks/pre_copy_last_published_workfile.py
+++ b/openpype/hooks/pre_copy_last_published_workfile.py
@@ -9,6 +9,7 @@ from openpype.lib import PreLaunchHook
 from openpype.lib.profiles_filtering import filter_profiles
 from openpype.settings.lib import get_project_settings
 from openpype.modules.sync_server.sync_server import (
+    get_last_published_workfile_path,
     download_last_published_workfile,
 )
 
@@ -140,7 +141,7 @@ class CopyLastPublishedWorkfile(PreLaunchHook):
         self.data["last_workfile_path"] = download_last_published_workfile(
             host_name,
             project_name,
-            self.data["asset_name"],
+            asset_name,
             task_name,
             published_workfile_path,
             workfile_representation,

--- a/openpype/hooks/pre_copy_last_published_workfile.py
+++ b/openpype/hooks/pre_copy_last_published_workfile.py
@@ -14,6 +14,7 @@ from openpype.pipeline.load.utils import get_representation_path
 from openpype.pipeline.template_data import get_template_data_with_names
 from openpype.pipeline.workfile.path_resolving import get_workfile_template_key
 from openpype.settings.lib import get_project_settings
+from openpype.modules.sync_server.sync_server import download_last_published_workfile
 
 
 class CopyLastPublishedWorkfile(PreLaunchHook):
@@ -98,6 +99,13 @@ class CopyLastPublishedWorkfile(PreLaunchHook):
             return
 
         self.log.info("Trying to fetch last published workfile...")
+        self.data["last_workfile_path"] = download_last_published_workfile(
+            host_name,
+            project_name,
+            self.data["asset_name"],
+            task_name
+        )
+        return
 
         project_doc = self.data.get("project_doc")
         asset_doc = self.data.get("asset_doc")

--- a/openpype/hooks/pre_copy_last_published_workfile.py
+++ b/openpype/hooks/pre_copy_last_published_workfile.py
@@ -14,7 +14,9 @@ from openpype.pipeline.load.utils import get_representation_path
 from openpype.pipeline.template_data import get_template_data_with_names
 from openpype.pipeline.workfile.path_resolving import get_workfile_template_key
 from openpype.settings.lib import get_project_settings
-from openpype.modules.sync_server.sync_server import download_last_published_workfile
+from openpype.modules.sync_server.sync_server import (
+    download_last_published_workfile,
+)
 
 
 class CopyLastPublishedWorkfile(PreLaunchHook):
@@ -40,11 +42,6 @@ class CopyLastPublishedWorkfile(PreLaunchHook):
         Returns:
             None: This is a void method.
         """
-
-        sync_server = self.modules_manager.get("sync_server")
-        if not sync_server or not sync_server.enabled:
-            self.log.debug("Sync server module is not enabled or available")
-            return
 
         # Check there is no workfile available
         last_workfile = self.data.get("last_workfile_path")
@@ -103,132 +100,8 @@ class CopyLastPublishedWorkfile(PreLaunchHook):
             host_name,
             project_name,
             self.data["asset_name"],
-            task_name
-        )
-        return
-
-        project_doc = self.data.get("project_doc")
-        asset_doc = self.data.get("asset_doc")
-        anatomy = self.data.get("anatomy")
-
-        # Check it can proceed
-        if not project_doc and not asset_doc:
-            return
-
-        # Get subset id
-        filtered_subsets = [
-            subset
-            for subset in get_subsets(
-                project_name,
-                asset_ids=[asset_doc["_id"]],
-                fields=["_id", "name", "data.family", "data.families"],
-            )
-            if (
-                subset["data"].get("family") == "workfile"
-                # Legacy compatibility
-                or "workfile" in subset["data"].get("families", {})
-            )
-        ]
-        if not filtered_subsets:
-            self.log.debug(
-                "No any subset for asset '{}' with id '{}'.".format(
-                    asset_name, asset_doc["_id"]
-                )
-            )
-            return
-
-        # Matching subset which has task name in its name
-        subset_id = None
-        low_task_name = task_name.lower()
-        if len(filtered_subsets) > 1:
-            for subset in filtered_subsets:
-                if low_task_name in subset["name"].lower():
-                    subset_id = subset["_id"]
-                    break
-        else:
-            subset_id = filtered_subsets[0]["_id"]
-
-        # Set default matched subset
-        if subset_id is None:
-            self.log.debug(
-                "No any matched subset for task '{}' of '{}'.".format(
-                    low_task_name, asset_name
-                )
-            )
-            return
-
-        # Get workfile representation
-        last_version_doc = get_last_version_by_subset_id(
-            project_name, subset_id, fields=["_id", "name"]
-        )
-        if not last_version_doc:
-            self.log.debug("Subset does not have any versions")
-            return
-
-        workfile_representation = next(
-            (
-                representation
-                for representation in get_representations(
-                    project_name, version_ids=[last_version_doc["_id"]]
-                )
-                if representation["context"]["task"]["name"] == task_name
-            ),
-            None,
-        )
-
-        if not workfile_representation:
-            self.log.debug(
-                'No published workfile for task "{}" and host "{}".'.format(
-                    task_name, host_name
-                )
-            )
-            return
-
-        local_site_id = get_local_site_id()
-
-        # Tag worfile and linked representations to be downloaded
-        representation_ids = {workfile_representation["_id"]}
-        representation_ids.update(
-            get_linked_representation_id(
-                project_name, repre_id=workfile_representation["_id"]
-            )
-        )
-        for repre_id in representation_ids:
-            sync_server.add_site(
-                project_name,
-                repre_id,
-                local_site_id,
-                force=True,
-                priority=99,
-                reset_timer=True,
-            )
-
-        while not sync_server.is_representation_on_site(
-            project_name, workfile_representation["_id"], local_site_id
-        ):
-            sleep(5)
-
-        # Get paths
-        published_workfile_path = get_representation_path(
-            workfile_representation, root=anatomy.roots
-        )
-
-        # Build workfile to copy and open's name from anatomy template settings
-        workfile_data = get_template_data_with_names(
-            project_name, asset_name, task_name, host_name
-        )
-        workfile_data["version"] = last_version_doc["name"] + 1
-        workfile_data["ext"] = os.path.splitext(published_workfile_path)[-1]
-        template_key = get_workfile_template_key(
-            task_type, host_name, project_name, project_settings
-        )
-        anatomy_result = anatomy.format(workfile_data)
-        local_workfile_path = anatomy_result[template_key]["path"]
-
-        # Copy file and substitute path
-        self.data["last_workfile_path"] = shutil.copy(
-            published_workfile_path,
-            local_workfile_path,
+            task_name,
+            last_workfile=last_workfile,
         )
 
         # Keep source filepath for further path conformation

--- a/openpype/hooks/pre_copy_last_published_workfile.py
+++ b/openpype/hooks/pre_copy_last_published_workfile.py
@@ -91,7 +91,6 @@ class CopyLastPublishedWorkfile(PreLaunchHook):
 
         self.log.info("Trying to fetch last published workfile...")
 
-        project_doc = self.data.get("project_doc")
         asset_doc = self.data.get("asset_doc")
         anatomy = self.data.get("anatomy")
 

--- a/openpype/hooks/pre_copy_last_published_workfile.py
+++ b/openpype/hooks/pre_copy_last_published_workfile.py
@@ -95,7 +95,7 @@ class CopyLastPublishedWorkfile(PreLaunchHook):
         asset_doc = self.data.get("asset_doc")
         anatomy = self.data.get("anatomy")
 
-        # Getting subset ID
+        # Get subset ID
         subset_id = match_subset_id(
             project_name, task_name, "workfile", asset_doc
         )
@@ -107,7 +107,7 @@ class CopyLastPublishedWorkfile(PreLaunchHook):
             )
             return
 
-        # Getting workfile representation
+        # Get workfile representation
         last_version_doc = get_last_version_by_subset_id(
             project_name, subset_id, fields=["_id", "name"]
         )

--- a/openpype/hooks/pre_copy_last_published_workfile.py
+++ b/openpype/hooks/pre_copy_last_published_workfile.py
@@ -1,22 +1,15 @@
 import os
-import shutil
-from time import sleep
 from openpype.client.entities import (
     get_last_version_by_subset_id,
-    get_representations,
-    get_subsets,
+    match_subset_id,
+    get_representation,
 )
-from openpype.client.entity_links import get_linked_representation_id
+
 from openpype.lib import PreLaunchHook
-from openpype.lib.local_settings import get_local_site_id
 from openpype.lib.profiles_filtering import filter_profiles
-from openpype.pipeline.load.utils import get_representation_path
-from openpype.pipeline.template_data import get_template_data_with_names
-from openpype.pipeline.workfile.path_resolving import get_workfile_template_key
 from openpype.settings.lib import get_project_settings
 from openpype.modules.sync_server.sync_server import (
     download_last_published_workfile,
-    get_subset_id,
 )
 
 
@@ -103,39 +96,13 @@ class CopyLastPublishedWorkfile(PreLaunchHook):
         anatomy = self.data.get("anatomy")
 
         # Getting subset ID
-        filtered_subsets = [
-            subset
-            for subset in get_subsets(
-                project_name,
-                asset_ids=[asset_doc["_id"]],
-                fields=["_id", "name", "data.family", "data.families"],
-            )
-            if (
-                subset["data"].get("family") == "workfile"
-                # Legacy compatibility
-                or "workfile" in subset["data"].get("families", {})
-            )
-        ]
-        if not filtered_subsets:
-            self.log.debug(
-                "No any subset for asset '{}' with id '{}'.".format(
-                    asset_name, asset_doc["_id"]
-                )
-            )
-            return
-
-        # Matching subset which has task name in its name
-        subset_id = None
-        low_task_name = task_name.lower()
-        if len(filtered_subsets) > 1:
-            for subset in filtered_subsets:
-                if low_task_name in subset["name"].lower():
-                    subset_id = subset["_id"]
-                    break
+        subset_id = match_subset_id(
+            project_name, task_name, "workfile", asset_doc
+        )
         if subset_id is None:
             self.log.debug(
-                "No any matched subset for task '{}' of '{}'.".format(
-                    low_task_name, asset_name
+                "Not any matched subset for task '{}' of '{}'.".format(
+                    task_name, asset_name
                 )
             )
             return
@@ -148,15 +115,10 @@ class CopyLastPublishedWorkfile(PreLaunchHook):
             self.log.debug("Subset does not have any versions")
             return
 
-        workfile_representation = next(
-            (
-                representation
-                for representation in get_representations(
-                    project_name, version_ids=[last_version_doc["_id"]]
-                )
-                if representation["context"]["task"]["name"] == task_name
-            ),
-            None,
+        workfile_representation = get_representation(
+            project_name,
+            task_name,
+            last_version_doc,
         )
         if not workfile_representation:
             self.log.debug(
@@ -166,6 +128,7 @@ class CopyLastPublishedWorkfile(PreLaunchHook):
             )
             return
 
+        # Get last published
         published_workfile_path = get_last_published_workfile_path(
             host_name,
             project_name,
@@ -187,127 +150,5 @@ class CopyLastPublishedWorkfile(PreLaunchHook):
             anatomy=anatomy,
             asset_doc=asset_doc,
         )
-        # Keep source filepath for further path conformation
-        self.data["source_filepath"] = published_workfile_path
-        return
-
-        # Check it can proceed
-        if not project_doc and not asset_doc:
-            return
-
-        # Get subset id
-        filtered_subsets = [
-            subset
-            for subset in get_subsets(
-                project_name,
-                asset_ids=[asset_doc["_id"]],
-                fields=["_id", "name", "data.family", "data.families"],
-            )
-            if (
-                subset["data"].get("family") == "workfile"
-                # Legacy compatibility
-                or "workfile" in subset["data"].get("families", {})
-            )
-        ]
-        if not filtered_subsets:
-            self.log.debug(
-                "No any subset for asset '{}' with id '{}'.".format(
-                    asset_name, asset_doc["_id"]
-                )
-            )
-            return
-
-        # Matching subset which has task name in its name
-        subset_id = None
-        low_task_name = task_name.lower()
-        if len(filtered_subsets) > 1:
-            for subset in filtered_subsets:
-                if low_task_name in subset["name"].lower():
-                    subset_id = subset["_id"]
-                    break
-
-        # Set default matched subset
-        if subset_id is None:
-            self.log.debug(
-                "No any matched subset for task '{}' of '{}'.".format(
-                    low_task_name, asset_name
-                )
-            )
-            return
-
-        # Get workfile representation
-        last_version_doc = get_last_version_by_subset_id(
-            project_name, subset_id, fields=["_id", "name"]
-        )
-        if not last_version_doc:
-            self.log.debug("Subset does not have any versions")
-            return
-
-        workfile_representation = next(
-            (
-                representation
-                for representation in get_representations(
-                    project_name, version_ids=[last_version_doc["_id"]]
-                )
-                if representation["context"]["task"]["name"] == task_name
-            ),
-            None,
-        )
-
-        if not workfile_representation:
-            self.log.debug(
-                'No published workfile for task "{}" and host "{}".'.format(
-                    task_name, host_name
-                )
-            )
-            return
-
-        local_site_id = get_local_site_id()
-
-        # Tag worfile and linked representations to be downloaded
-        representation_ids = {workfile_representation["_id"]}
-        representation_ids.update(
-            get_linked_representation_id(
-                project_name, repre_id=workfile_representation["_id"]
-            )
-        )
-        for repre_id in representation_ids:
-            sync_server.add_site(
-                project_name,
-                repre_id,
-                local_site_id,
-                force=True,
-                priority=99,
-                reset_timer=True,
-            )
-
-        while not sync_server.is_representation_on_site(
-            project_name, workfile_representation["_id"], local_site_id
-        ):
-            sleep(5)
-
-        # Get paths
-        published_workfile_path = get_representation_path(
-            workfile_representation, root=anatomy.roots
-        )
-
-        # Build workfile to copy and open's name from anatomy template settings
-        workfile_data = get_template_data_with_names(
-            project_name, asset_name, task_name, host_name
-        )
-        workfile_data["version"] = last_version_doc["name"] + 1
-        workfile_data["ext"] = os.path.splitext(published_workfile_path)[-1]
-        template_key = get_workfile_template_key(
-            task_type, host_name, project_name, project_settings
-        )
-        anatomy_result = anatomy.format(workfile_data)
-        local_workfile_path = anatomy_result[template_key]["path"]
-
-        # Copy file and substitute path
-        self.data["last_workfile_path"] = shutil.copy(
-            published_workfile_path,
-            local_workfile_path,
-        )
-
         # Keep source filepath for further path conformation
         self.data["source_filepath"] = published_workfile_path

--- a/openpype/hooks/pre_copy_last_published_workfile.py
+++ b/openpype/hooks/pre_copy_last_published_workfile.py
@@ -2,7 +2,7 @@ import os
 from openpype.client.entities import (
     get_last_version_by_subset_id,
     match_subset_id,
-    get_representation_with_task,
+    get_representation_by_task,
 )
 
 from openpype.lib import PreLaunchHook
@@ -115,7 +115,7 @@ class CopyLastPublishedWorkfile(PreLaunchHook):
             self.log.debug("Subset does not have any versions")
             return
 
-        workfile_representation = get_representation_with_task(
+        workfile_representation = get_representation_by_task(
             project_name,
             task_name,
             last_version_doc,

--- a/openpype/hooks/pre_copy_last_published_workfile.py
+++ b/openpype/hooks/pre_copy_last_published_workfile.py
@@ -2,7 +2,7 @@ import os
 from openpype.client.entities import (
     get_last_version_by_subset_id,
     match_subset_id,
-    get_representation,
+    get_representation_with_task,
 )
 
 from openpype.lib import PreLaunchHook
@@ -115,7 +115,7 @@ class CopyLastPublishedWorkfile(PreLaunchHook):
             self.log.debug("Subset does not have any versions")
             return
 
-        workfile_representation = get_representation(
+        workfile_representation = get_representation_with_task(
             project_name,
             task_name,
             last_version_doc,

--- a/openpype/modules/sync_server/sync_server.py
+++ b/openpype/modules/sync_server/sync_server.py
@@ -22,29 +22,18 @@ from openpype.client.entities import get_asset_by_name
 from .utils import SyncStatus, ResumableError
 
 
-async def upload(
-    module,
-    project_name,
-    file,
-    representation,
-    provider_name,
-    remote_site_name,
-    tree=None,
-    preset=None,
-):
+async def upload(module, project_name, file, representation, provider_name,
+                 remote_site_name, tree=None, preset=None):
     """
         Upload single 'file' of a 'representation' to 'provider'.
         Source url is taken from 'file' portion, where {root} placeholder
         is replaced by 'representation.Context.root'
         Provider could be one of implemented in provider.py.
-
         Updates MongoDB, fills in id of file from provider (ie. file_id
         from GDrive), 'created_dt' - time of upload
-
         'provider_name' doesn't have to match to 'site_name', single
         provider (GDrive) might have multiple sites ('projectA',
         'projectB')
-
     Args:
         module(SyncServerModule): object to run SyncServerModule API
         project_name (str): source db
@@ -61,22 +50,17 @@ async def upload(
         # this part modifies structure on 'remote_site', only single
         # thread can do that at a time, upload/download to prepared
         # structure should be run in parallel
-        remote_handler = lib.factory.get_provider(
-            provider_name,
-            project_name,
-            remote_site_name,
-            tree=tree,
-            presets=preset,
-        )
+        remote_handler = lib.factory.get_provider(provider_name,
+                                                  project_name,
+                                                  remote_site_name,
+                                                  tree=tree,
+                                                  presets=preset)
 
         file_path = file.get("path", "")
         try:
             local_file_path, remote_file_path = resolve_paths(
-                module,
-                file_path,
-                project_name,
-                remote_site_name,
-                remote_handler,
+                module, file_path, project_name,
+                remote_site_name, remote_handler
             )
         except Exception as exp:
             print(exp)
@@ -85,45 +69,34 @@ async def upload(
         folder_id = remote_handler.create_folder(target_folder)
 
         if not folder_id:
-            err = "Folder {} wasn't created. Check permissions.".format(
-                target_folder
-            )
+            err = "Folder {} wasn't created. Check permissions.". \
+                format(target_folder)
             raise NotADirectoryError(err)
 
     loop = asyncio.get_running_loop()
-    file_id = await loop.run_in_executor(
-        None,
-        remote_handler.upload_file,
-        local_file_path,
-        remote_file_path,
-        module,
-        project_name,
-        file,
-        representation,
-        remote_site_name,
-        True,
-    )
+    file_id = await loop.run_in_executor(None,
+                                         remote_handler.upload_file,
+                                         local_file_path,
+                                         remote_file_path,
+                                         module,
+                                         project_name,
+                                         file,
+                                         representation,
+                                         remote_site_name,
+                                         True
+                                         )
 
-    module.handle_alternate_site(
-        project_name, representation, remote_site_name, file["_id"], file_id
-    )
+    module.handle_alternate_site(project_name, representation,
+                                 remote_site_name,
+                                 file["_id"], file_id)
 
     return file_id
 
 
-async def download(
-    module,
-    project_name,
-    file,
-    representation,
-    provider_name,
-    remote_site_name,
-    tree=None,
-    preset=None,
-):
+async def download(module, project_name, file, representation, provider_name,
+                   remote_site_name, tree=None, preset=None):
     """
         Downloads file to local folder denoted in representation.Context.
-
     Args:
         module(SyncServerModule): object to run SyncServerModule API
         project_name (str): source
@@ -134,18 +107,15 @@ async def download(
             have multiple sites (different accounts, credentials)
         tree (dictionary): injected memory structure for performance
         preset (dictionary): site config ('credentials_url', 'root'...)
-
         Returns:
         (string) - 'name' of local file
     """
     with module.lock:
-        remote_handler = lib.factory.get_provider(
-            provider_name,
-            project_name,
-            remote_site_name,
-            tree=tree,
-            presets=preset,
-        )
+        remote_handler = lib.factory.get_provider(provider_name,
+                                                  project_name,
+                                                  remote_site_name,
+                                                  tree=tree,
+                                                  presets=preset)
 
         file_path = file.get("path", "")
         local_file_path, remote_file_path = resolve_paths(
@@ -158,51 +128,45 @@ async def download(
     local_site = module.get_active_site(project_name)
 
     loop = asyncio.get_running_loop()
-    file_id = await loop.run_in_executor(
-        None,
-        remote_handler.download_file,
-        remote_file_path,
-        local_file_path,
-        module,
-        project_name,
-        file,
-        representation,
-        local_site,
-        True,
-    )
+    file_id = await loop.run_in_executor(None,
+                                         remote_handler.download_file,
+                                         remote_file_path,
+                                         local_file_path,
+                                         module,
+                                         project_name,
+                                         file,
+                                         representation,
+                                         local_site,
+                                         True
+                                         )
 
-    module.handle_alternate_site(
-        project_name, representation, local_site, file["_id"], file_id
-    )
+    module.handle_alternate_site(project_name, representation, local_site,
+                                 file["_id"], file_id)
 
     return file_id
 
 
-def resolve_paths(
-    module, file_path, project_name, remote_site_name=None, remote_handler=None
-):
+def resolve_paths(module, file_path, project_name,
+                  remote_site_name=None, remote_handler=None):
     """
-    Returns tuple of local and remote file paths with {root}
-    placeholders replaced with proper values from Settings or Anatomy
-
-    Ejected here because of Python 2 hosts (GDriveHandler is an issue)
-
-    Args:
-        module(SyncServerModule): object to run SyncServerModule API
-        file_path(string): path with {root}
-        project_name(string): project name
-        remote_site_name(string): remote site
-        remote_handler(AbstractProvider): implementation
-    Returns:
-        (string, string) - proper absolute paths, remote path is optional
+        Returns tuple of local and remote file paths with {root}
+        placeholders replaced with proper values from Settings or Anatomy
+        Ejected here because of Python 2 hosts (GDriveHandler is an issue)
+        Args:
+            module(SyncServerModule): object to run SyncServerModule API
+            file_path(string): path with {root}
+            project_name(string): project name
+            remote_site_name(string): remote site
+            remote_handler(AbstractProvider): implementation
+        Returns:
+            (string, string) - proper absolute paths, remote path is optional
     """
-    remote_file_path = ""
+    remote_file_path = ''
     if remote_handler:
         remote_file_path = remote_handler.resolve_path(file_path)
 
     local_handler = lib.factory.get_provider(
-        "local_drive", project_name, module.get_active_site(project_name)
-    )
+        'local_drive', project_name, module.get_active_site(project_name))
     local_file_path = local_handler.resolve_path(file_path)
 
     return local_file_path, remote_file_path
@@ -210,16 +174,14 @@ def resolve_paths(
 
 def site_is_working(module, project_name, site_name):
     """
-    Confirm that 'site_name' is configured correctly for 'project_name'.
-
-    Must be here as lib.factory access doesn't work in Python 2 hosts.
-
-    Args:
-        module (SyncServerModule)
-        project_name(string):
-        site_name(string):
-    Returns
-        (bool)
+        Confirm that 'site_name' is configured correctly for 'project_name'.
+        Must be here as lib.factory access doesn't work in Python 2 hosts.
+        Args:
+            module (SyncServerModule)
+            project_name(string):
+            site_name(string):
+        Returns
+            (bool)
     """
     if _get_configured_sites(module, project_name).get(site_name):
         return True
@@ -228,16 +190,15 @@ def site_is_working(module, project_name, site_name):
 
 def _get_configured_sites(module, project_name):
     """
-    Loops through settings and looks for configured sites and checks
-    its handlers for particular 'project_name'.
-
-    Args:
-        project_setting(dict): dictionary from Settings
-        only_project_name(string, optional): only interested in
-            particular project
-    Returns:
-        (dict of dict)
-        {'ProjectA': {'studio':True, 'gdrive':False}}
+        Loops through settings and looks for configured sites and checks
+        its handlers for particular 'project_name'.
+        Args:
+            project_setting(dict): dictionary from Settings
+            only_project_name(string, optional): only interested in
+                particular project
+        Returns:
+            (dict of dict)
+            {'ProjectA': {'studio':True, 'gdrive':False}}
     """
     settings = module.get_sync_project_setting(project_name)
     return _get_configured_sites_from_setting(module, project_name, settings)
@@ -255,17 +216,18 @@ def _get_configured_sites_from_setting(module, project_name, project_setting):
         provider = module.get_provider_for_site(site=site_name)
         handler = initiated_handlers.get((provider, site_name))
         if not handler:
-            handler = lib.factory.get_provider(
-                provider, project_name, site_name, presets=config
-            )
-            initiated_handlers[(provider, site_name)] = handler
+            handler = lib.factory.get_provider(provider,
+                                               project_name,
+                                               site_name,
+                                               presets=config)
+            initiated_handlers[(provider, site_name)] = \
+                handler
 
         if handler.is_active():
             configured_sites[site_name] = True
 
     return configured_sites
-
-
+    
 def get_last_published_workfile_path(
     host_name: str,
     project_name: str,
@@ -438,10 +400,9 @@ def download_last_published_workfile(
 
 class SyncServerThread(threading.Thread):
     """
-    Separate thread running synchronization server with asyncio loop.
-    Stopped when tray is closed.
+        Separate thread running synchronization server with asyncio loop.
+        Stopped when tray is closed.
     """
-
     def __init__(self, module):
         self.log = Logger.get_logger(self.__class__.__name__)
 
@@ -466,7 +427,9 @@ class SyncServerThread(threading.Thread):
             self.log.info("Sync Server Started")
             self.loop.run_forever()
         except Exception:
-            self.log.warning("Sync Server service has failed", exc_info=True)
+            self.log.warning(
+                "Sync Server service has failed", exc_info=True
+            )
         finally:
             self.loop.close()  # optional
 
@@ -482,12 +445,10 @@ class SyncServerThread(threading.Thread):
                 - update representations - fills error messages for exceptions
                 - waits X seconds and repeat
         Returns:
-
         """
         while self.is_running and not self.module.is_paused():
             try:
                 import time
-
                 start_time = time.time()
                 self.module.set_sync_project_settings()  # clean cache
                 project_name = None
@@ -500,7 +461,9 @@ class SyncServerThread(threading.Thread):
                         continue
 
                     sync_repres = self.module.get_sync_representations(
-                        project_name, local_site, remote_site
+                        project_name,
+                        local_site,
+                        remote_site
                     )
 
                     task_files_to_process = []
@@ -512,24 +475,21 @@ class SyncServerThread(threading.Thread):
                     # reuse same id
                     processed_file_path = set()
 
-                    site_preset = preset.get("sites")[remote_site]
-                    remote_provider = self.module.get_provider_for_site(
-                        site=remote_site
-                    )
-                    handler = lib.factory.get_provider(
-                        remote_provider,
-                        project_name,
-                        remote_site,
-                        presets=site_preset,
-                    )
+                    site_preset = preset.get('sites')[remote_site]
+                    remote_provider = \
+                        self.module.get_provider_for_site(site=remote_site)
+                    handler = lib.factory.get_provider(remote_provider,
+                                                       project_name,
+                                                       remote_site,
+                                                       presets=site_preset)
                     limit = lib.factory.get_provider_batch_limit(
-                        remote_provider
-                    )
+                        remote_provider)
                     # first call to get_provider could be expensive, its
                     # building folder tree structure in memory
                     # call only if needed, eg. DO_UPLOAD or DO_DOWNLOAD
                     for sync in sync_repres:
-                        if self.module.is_representation_paused(sync["_id"]):
+                        if self.module.\
+                                is_representation_paused(sync['_id']):
                             continue
                         if limit <= 0:
                             continue
@@ -537,82 +497,74 @@ class SyncServerThread(threading.Thread):
                         if files:
                             for file in files:
                                 # skip already processed files
-                                file_path = file.get("path", "")
+                                file_path = file.get('path', '')
                                 if file_path in processed_file_path:
                                     continue
                                 status = self.module.check_status(
                                     file,
                                     local_site,
                                     remote_site,
-                                    preset.get("config"),
-                                )
+                                    preset.get('config'))
                                 if status == SyncStatus.DO_UPLOAD:
                                     tree = handler.get_tree()
                                     limit -= 1
                                     task = asyncio.create_task(
-                                        upload(
-                                            self.module,
-                                            project_name,
-                                            file,
-                                            sync,
-                                            remote_provider,
-                                            remote_site,
-                                            tree,
-                                            site_preset,
-                                        )
-                                    )
+                                        upload(self.module,
+                                               project_name,
+                                               file,
+                                               sync,
+                                               remote_provider,
+                                               remote_site,
+                                               tree,
+                                               site_preset))
                                     task_files_to_process.append(task)
                                     # store info for exception handlingy
-                                    files_processed_info.append(
-                                        (file, sync, remote_site, project_name)
-                                    )
+                                    files_processed_info.append((file,
+                                                                 sync,
+                                                                 remote_site,
+                                                                 project_name
+                                                                 ))
                                     processed_file_path.add(file_path)
                                 if status == SyncStatus.DO_DOWNLOAD:
                                     tree = handler.get_tree()
                                     limit -= 1
                                     task = asyncio.create_task(
-                                        download(
-                                            self.module,
-                                            project_name,
-                                            file,
-                                            sync,
-                                            remote_provider,
-                                            remote_site,
-                                            tree,
-                                            site_preset,
-                                        )
-                                    )
+                                        download(self.module,
+                                                 project_name,
+                                                 file,
+                                                 sync,
+                                                 remote_provider,
+                                                 remote_site,
+                                                 tree,
+                                                 site_preset))
                                     task_files_to_process.append(task)
 
-                                    files_processed_info.append(
-                                        (file, sync, local_site, project_name)
-                                    )
+                                    files_processed_info.append((file,
+                                                                 sync,
+                                                                 local_site,
+                                                                 project_name
+                                                                 ))
                                     processed_file_path.add(file_path)
 
-                    self.log.debug(
-                        "Sync tasks count {}".format(
-                            len(task_files_to_process)
-                        )
-                    )
+                    self.log.debug("Sync tasks count {}".format(
+                        len(task_files_to_process)
+                    ))
                     files_created = await asyncio.gather(
-                        *task_files_to_process, return_exceptions=True
-                    )
-                    for file_id, info in zip(
-                        files_created, files_processed_info
-                    ):
+                        *task_files_to_process,
+                        return_exceptions=True)
+                    for file_id, info in zip(files_created,
+                                             files_processed_info):
                         file, representation, site, project_name = info
                         error = None
                         if isinstance(file_id, BaseException):
                             error = str(file_id)
                             file_id = None
-                        self.module.update_db(
-                            project_name,
-                            file_id,
-                            file,
-                            representation,
-                            site,
-                            error,
-                        )
+                        self.module.update_db(project_name,
+                                              file_id,
+                                              file,
+                                              representation,
+                                              site,
+                                              error)
 
                 duration = time.time() - start_time
                 self.log.debug("One loop took {:.2f}s".format(duration))
@@ -627,30 +579,27 @@ class SyncServerThread(threading.Thread):
             except ConnectionResetError:
                 self.log.warning(
                     "ConnectionResetError in sync loop, trying next loop",
-                    exc_info=True,
-                )
+                    exc_info=True)
             except CancelledError:
                 # just stopping server
                 pass
             except ResumableError:
                 self.log.warning(
                     "ResumableError in sync loop, trying next loop",
-                    exc_info=True,
-                )
+                    exc_info=True)
             except Exception:
                 self.stop()
                 self.log.warning(
                     "Unhandled except. in sync loop, stopping server",
-                    exc_info=True,
-                )
+                    exc_info=True)
 
     def stop(self):
         """Sets is_running flag to false, 'check_shutdown' shuts server down"""
         self.is_running = False
 
     async def check_shutdown(self):
-        """Future that is running and checks if server should be running
-        periodically.
+        """ Future that is running and checks if server should be running
+            periodically.
         """
         while self.is_running:
             if self.module.long_running_tasks:
@@ -660,16 +609,12 @@ class SyncServerThread(threading.Thread):
                 self.log.info("finished long running")
                 self.module.projects_processed.remove(task["project_name"])
             await asyncio.sleep(0.5)
-        tasks = [
-            task
-            for task in asyncio.all_tasks()
-            if task is not asyncio.current_task()
-        ]
+        tasks = [task for task in asyncio.all_tasks() if
+                 task is not asyncio.current_task()]
         list(map(lambda task: task.cancel(), tasks))  # cancel all the tasks
         results = await asyncio.gather(*tasks, return_exceptions=True)
         self.log.debug(
-            f"Finished awaiting cancelled tasks, results: {results}..."
-        )
+            f'Finished awaiting cancelled tasks, results: {results}...')
         await self.loop.shutdown_asyncgens()
         # to really make sure everything else has time to stop
         self.executor.shutdown(wait=True)
@@ -695,15 +640,13 @@ class SyncServerThread(threading.Thread):
         local_site = self.module.get_active_site(project_name)
         remote_site = self.module.get_remote_site(project_name)
         if local_site == remote_site:
-            self.log.debug(
-                "{}-{} sites same, skipping".format(local_site, remote_site)
-            )
+            self.log.debug("{}-{} sites same, skipping".format(
+                local_site, remote_site))
             return None, None
 
         configured_sites = _get_configured_sites(self.module, project_name)
-        if not all(
-            [local_site in configured_sites, remote_site in configured_sites]
-        ):
+        if not all([local_site in configured_sites,
+                    remote_site in configured_sites]):
             self.log.debug(
                 "Some of the sites {} - {} is not working properly".format(
                     local_site, remote_site

--- a/openpype/modules/sync_server/sync_server.py
+++ b/openpype/modules/sync_server/sync_server.py
@@ -288,7 +288,7 @@ def download_last_published_workfile(
     anatomy: Anatomy = None,
     asset_doc: dict = None,
 ) -> str:
-    """Download the last pusblished workfile, and returns its path.
+    """Download the last pusblished workfile, and return its path.
 
     Args:
         host_name (str): Host name.

--- a/openpype/modules/sync_server/sync_server.py
+++ b/openpype/modules/sync_server/sync_server.py
@@ -248,12 +248,15 @@ def get_last_published_workfile_path(
     anatomy: Anatomy = None,
 ) -> str:
     """Returns last published workfile path.
+
     Args:
         host_name (str): Host name.
         project_name (str): Project name.
         task_name (str): Task name.
         workfile_representation (dict): Workfile representation.
-        anatomy (Anatomy, optional): Anatomy. Defaults to None.
+        anatomy (Anatomy, optional): Anatomy (Used for optimization).
+            Defaults to None.
+
     Returns:
         str: Last published workfile path.
     """
@@ -285,7 +288,8 @@ def download_last_published_workfile(
     anatomy: Anatomy = None,
     asset_doc: dict = None,
 ) -> str:
-    """Downloads the last pusblished workfile, and returns its path.
+    """Download the last pusblished workfile, and returns its path.
+
     Args:
         host_name (str): Host name.
         project_name (str): Project name.
@@ -296,8 +300,11 @@ def download_last_published_workfile(
         workfile_representation (dict): Workfile representation.
         subset_id (str): Subset ID.
         last_version_doc (dict): Last version doc.
-        anatomy (Anatomy, optional): Anatomy. Defaults to None.
-        asset_doc (dict, optional): Asset doc. Defaults to None.
+        anatomy (Anatomy, optional): Anatomy (Used for optimization).
+            Defaults to None.
+        asset_doc (dict, optional): Asset doc (Used for optimization).
+            Defaults to None.
+
     Returns:
         str: New local workfile path.
     """
@@ -308,7 +315,7 @@ def download_last_published_workfile(
     if not asset_doc:
         asset_doc = get_asset_by_name(project_name, asset_name)
 
-    # Getting sync server module
+    # Get sync server module
     sync_server = ModulesManager().modules_by_name.get("sync_server")
     if not sync_server or not sync_server.enabled:
         print("Sync server module is disabled or unavailable.")
@@ -343,16 +350,10 @@ def download_last_published_workfile(
         )
         return
 
+    # Get local site
     local_site_id = get_local_site_id()
-    sync_server.add_site(
-        project_name,
-        workfile_representation["_id"],
-        local_site_id,
-        force=True,
-        priority=99,
-        reset_timer=True,
-    )
 
+    # Add workfile representation to local site
     representation_ids = {workfile_representation["_id"]}
     representation_ids.update(
         get_linked_representation_id(
@@ -384,7 +385,7 @@ def download_last_published_workfile(
             anatomy=anatomy,
         )
 
-    # Getting workfile data
+    # Get workfile data
     workfile_data = get_template_data_with_names(
         project_name, asset_name, task_name, host_name
     )

--- a/openpype/modules/sync_server/sync_server.py
+++ b/openpype/modules/sync_server/sync_server.py
@@ -288,7 +288,7 @@ def download_last_published_workfile(
     anatomy: Anatomy = None,
     asset_doc: dict = None,
 ) -> str:
-    """Download the last pusblished workfile, and return its path.
+    """Download the last published workfile, and return its path.
 
     Args:
         host_name (str): Host name.

--- a/openpype/modules/sync_server/sync_server.py
+++ b/openpype/modules/sync_server/sync_server.py
@@ -330,7 +330,7 @@ def download_last_published_workfile(
         )
         return
 
-    # If represenation isn't available on remote site, then return.
+    # If representation isn't available on remote site, then return.
     if not sync_server.is_representation_on_site(
         project_name,
         workfile_representation["_id"],

--- a/openpype/modules/sync_server/sync_server.py
+++ b/openpype/modules/sync_server/sync_server.py
@@ -1,18 +1,50 @@
 """Python 3 only implementation."""
 import os
+import shutil
 import asyncio
 import threading
 import concurrent.futures
+from time import sleep
 from concurrent.futures._base import CancelledError
 
 from .providers import lib
 from openpype.lib import Logger
+from openpype.lib.local_settings import get_local_site_id
+from openpype.lib.path_tools import version_up
+from openpype.modules.base import ModulesManager
+from openpype.pipeline import Anatomy
+from openpype.pipeline.template_data import (
+    get_template_data,
+    get_template_data_with_names,
+)
+from openpype.pipeline.load.utils import get_representation_path_with_anatomy
+from openpype.pipeline.workfile.path_resolving import (
+    get_last_workfile,
+    get_workdir,
+    get_workfile_template_key,
+)
+from openpype.settings.lib import get_project_settings
+from openpype.client.entities import (
+    get_last_version_by_subset_id,
+    get_representations,
+    get_subsets,
+    get_project,
+    get_asset_by_name,
+)
 
 from .utils import SyncStatus, ResumableError
 
 
-async def upload(module, project_name, file, representation, provider_name,
-                 remote_site_name, tree=None, preset=None):
+async def upload(
+    module,
+    project_name,
+    file,
+    representation,
+    provider_name,
+    remote_site_name,
+    tree=None,
+    preset=None,
+):
     """
         Upload single 'file' of a 'representation' to 'provider'.
         Source url is taken from 'file' portion, where {root} placeholder
@@ -43,17 +75,22 @@ async def upload(module, project_name, file, representation, provider_name,
         # this part modifies structure on 'remote_site', only single
         # thread can do that at a time, upload/download to prepared
         # structure should be run in parallel
-        remote_handler = lib.factory.get_provider(provider_name,
-                                                  project_name,
-                                                  remote_site_name,
-                                                  tree=tree,
-                                                  presets=preset)
+        remote_handler = lib.factory.get_provider(
+            provider_name,
+            project_name,
+            remote_site_name,
+            tree=tree,
+            presets=preset,
+        )
 
         file_path = file.get("path", "")
         try:
             local_file_path, remote_file_path = resolve_paths(
-                module, file_path, project_name,
-                remote_site_name, remote_handler
+                module,
+                file_path,
+                project_name,
+                remote_site_name,
+                remote_handler,
             )
         except Exception as exp:
             print(exp)
@@ -62,32 +99,42 @@ async def upload(module, project_name, file, representation, provider_name,
         folder_id = remote_handler.create_folder(target_folder)
 
         if not folder_id:
-            err = "Folder {} wasn't created. Check permissions.". \
-                format(target_folder)
+            err = "Folder {} wasn't created. Check permissions.".format(
+                target_folder
+            )
             raise NotADirectoryError(err)
 
     loop = asyncio.get_running_loop()
-    file_id = await loop.run_in_executor(None,
-                                         remote_handler.upload_file,
-                                         local_file_path,
-                                         remote_file_path,
-                                         module,
-                                         project_name,
-                                         file,
-                                         representation,
-                                         remote_site_name,
-                                         True
-                                         )
+    file_id = await loop.run_in_executor(
+        None,
+        remote_handler.upload_file,
+        local_file_path,
+        remote_file_path,
+        module,
+        project_name,
+        file,
+        representation,
+        remote_site_name,
+        True,
+    )
 
-    module.handle_alternate_site(project_name, representation,
-                                 remote_site_name,
-                                 file["_id"], file_id)
+    module.handle_alternate_site(
+        project_name, representation, remote_site_name, file["_id"], file_id
+    )
 
     return file_id
 
 
-async def download(module, project_name, file, representation, provider_name,
-                   remote_site_name, tree=None, preset=None):
+async def download(
+    module,
+    project_name,
+    file,
+    representation,
+    provider_name,
+    remote_site_name,
+    tree=None,
+    preset=None,
+):
     """
         Downloads file to local folder denoted in representation.Context.
 
@@ -106,11 +153,13 @@ async def download(module, project_name, file, representation, provider_name,
         (string) - 'name' of local file
     """
     with module.lock:
-        remote_handler = lib.factory.get_provider(provider_name,
-                                                  project_name,
-                                                  remote_site_name,
-                                                  tree=tree,
-                                                  presets=preset)
+        remote_handler = lib.factory.get_provider(
+            provider_name,
+            project_name,
+            remote_site_name,
+            tree=tree,
+            presets=preset,
+        )
 
         file_path = file.get("path", "")
         local_file_path, remote_file_path = resolve_paths(
@@ -123,47 +172,51 @@ async def download(module, project_name, file, representation, provider_name,
     local_site = module.get_active_site(project_name)
 
     loop = asyncio.get_running_loop()
-    file_id = await loop.run_in_executor(None,
-                                         remote_handler.download_file,
-                                         remote_file_path,
-                                         local_file_path,
-                                         module,
-                                         project_name,
-                                         file,
-                                         representation,
-                                         local_site,
-                                         True
-                                         )
+    file_id = await loop.run_in_executor(
+        None,
+        remote_handler.download_file,
+        remote_file_path,
+        local_file_path,
+        module,
+        project_name,
+        file,
+        representation,
+        local_site,
+        True,
+    )
 
-    module.handle_alternate_site(project_name, representation, local_site,
-                                 file["_id"], file_id)
+    module.handle_alternate_site(
+        project_name, representation, local_site, file["_id"], file_id
+    )
 
     return file_id
 
 
-def resolve_paths(module, file_path, project_name,
-                  remote_site_name=None, remote_handler=None):
+def resolve_paths(
+    module, file_path, project_name, remote_site_name=None, remote_handler=None
+):
     """
-        Returns tuple of local and remote file paths with {root}
-        placeholders replaced with proper values from Settings or Anatomy
+    Returns tuple of local and remote file paths with {root}
+    placeholders replaced with proper values from Settings or Anatomy
 
-        Ejected here because of Python 2 hosts (GDriveHandler is an issue)
+    Ejected here because of Python 2 hosts (GDriveHandler is an issue)
 
-        Args:
-            module(SyncServerModule): object to run SyncServerModule API
-            file_path(string): path with {root}
-            project_name(string): project name
-            remote_site_name(string): remote site
-            remote_handler(AbstractProvider): implementation
-        Returns:
-            (string, string) - proper absolute paths, remote path is optional
+    Args:
+        module(SyncServerModule): object to run SyncServerModule API
+        file_path(string): path with {root}
+        project_name(string): project name
+        remote_site_name(string): remote site
+        remote_handler(AbstractProvider): implementation
+    Returns:
+        (string, string) - proper absolute paths, remote path is optional
     """
-    remote_file_path = ''
+    remote_file_path = ""
     if remote_handler:
         remote_file_path = remote_handler.resolve_path(file_path)
 
     local_handler = lib.factory.get_provider(
-        'local_drive', project_name, module.get_active_site(project_name))
+        "local_drive", project_name, module.get_active_site(project_name)
+    )
     local_file_path = local_handler.resolve_path(file_path)
 
     return local_file_path, remote_file_path
@@ -171,16 +224,16 @@ def resolve_paths(module, file_path, project_name,
 
 def site_is_working(module, project_name, site_name):
     """
-        Confirm that 'site_name' is configured correctly for 'project_name'.
+    Confirm that 'site_name' is configured correctly for 'project_name'.
 
-        Must be here as lib.factory access doesn't work in Python 2 hosts.
+    Must be here as lib.factory access doesn't work in Python 2 hosts.
 
-        Args:
-            module (SyncServerModule)
-            project_name(string):
-            site_name(string):
-        Returns
-            (bool)
+    Args:
+        module (SyncServerModule)
+        project_name(string):
+        site_name(string):
+    Returns
+        (bool)
     """
     if _get_configured_sites(module, project_name).get(site_name):
         return True
@@ -189,16 +242,16 @@ def site_is_working(module, project_name, site_name):
 
 def _get_configured_sites(module, project_name):
     """
-        Loops through settings and looks for configured sites and checks
-        its handlers for particular 'project_name'.
+    Loops through settings and looks for configured sites and checks
+    its handlers for particular 'project_name'.
 
-        Args:
-            project_setting(dict): dictionary from Settings
-            only_project_name(string, optional): only interested in
-                particular project
-        Returns:
-            (dict of dict)
-            {'ProjectA': {'studio':True, 'gdrive':False}}
+    Args:
+        project_setting(dict): dictionary from Settings
+        only_project_name(string, optional): only interested in
+            particular project
+    Returns:
+        (dict of dict)
+        {'ProjectA': {'studio':True, 'gdrive':False}}
     """
     settings = module.get_sync_project_setting(project_name)
     return _get_configured_sites_from_setting(module, project_name, settings)
@@ -216,12 +269,10 @@ def _get_configured_sites_from_setting(module, project_name, project_setting):
         provider = module.get_provider_for_site(site=site_name)
         handler = initiated_handlers.get((provider, site_name))
         if not handler:
-            handler = lib.factory.get_provider(provider,
-                                               project_name,
-                                               site_name,
-                                               presets=config)
-            initiated_handlers[(provider, site_name)] = \
-                handler
+            handler = lib.factory.get_provider(
+                provider, project_name, site_name, presets=config
+            )
+            initiated_handlers[(provider, site_name)] = handler
 
         if handler.is_active():
             configured_sites[site_name] = True
@@ -229,11 +280,162 @@ def _get_configured_sites_from_setting(module, project_name, project_setting):
     return configured_sites
 
 
+def get_last_published_workfile_path(
+    host_name: str, project_name: str, asset_name: str, task_name: str, anatomy: Anatomy=None, asset_doc: dict=None, workfile_representation: dict=None
+) -> str:
+    if not anatomy:
+        anatomy = Anatomy(project_name)
+    if not asset_doc:
+        asset_doc = get_asset_by_name(project_name, asset_name)
+
+    # Get subset id
+    subset_id = next(
+        (
+            subset["_id"]
+            for subset in get_subsets(
+                project_name,
+                asset_ids=[asset_doc["_id"]],
+                fields=["_id", "data.family", "data.families"],
+            )
+            if subset["data"].get("family") == "workfile"
+            # Legacy compatibility
+            or "workfile" in subset["data"].get("families", {})
+        ),
+        None,
+    )
+    if not subset_id:
+        print("Subset id not found for asset '{}'.".format(asset_doc["name"]))
+        return
+
+    # Get workfile representation
+    last_version_doc = get_last_version_by_subset_id(
+        project_name, subset_id, fields=["_id"]
+    )
+    if not last_version_doc:
+        print("Subset does not have any version.")
+        return
+
+    if not workfile_representation:
+        workfile_representation = next(
+            (
+                representation
+                for representation in get_representations(
+                    project_name, versions_ids=[last_version_doc["_id"]]
+                )
+                if representation["context"]["task"]["name"] == task_name
+            ),
+            None,
+        )
+        if not workfile_representation:
+            print(
+                "No published workfilefor task '{}' and host '{}'.".format(
+                    task_name, host_name
+                )
+            )
+            return
+
+    return get_representation_path_with_anatomy(
+        workfile_representation, anatomy
+    )
+
+
+def download_last_published_workfile(
+    host_name: str, project_name: str, asset_name: str, task_name: str
+) -> str:
+    # sync server, last workfile
+    # TODO: differentiate new workfile vs updated workfile
+    anatomy = Anatomy(
+        project_name
+    )
+    project_doc = get_project(project_name)
+    asset_doc = get_asset_by_name(
+        project_name, asset_name
+    )
+
+    sync_server = ModulesManager().modules_by_name.get("sync_server")
+    if not sync_server or not sync_server.enabled:
+        print("Sunc server module is disabled or unavailable.")
+        return
+
+    last_workfile = get_last_workfile(
+        get_workdir(
+            project_doc, asset_doc, task_name, host_name, anatomy=anatomy
+        ),
+        str(
+            anatomy.templates[
+                get_workfile_template_key(
+                    task_name,
+                    host_name,
+                    project_name,
+                )
+            ]["file"]
+        ),
+        get_template_data(
+            project_doc,
+            asset_doc=asset_doc,
+            task_name=task_name,
+            host_name=host_name,
+        ),
+        file_extensions,
+        full_path=True,
+    )
+    # Not sure if this is always correct
+    if os.path.exists(last_workfile):
+        print("Last workfile exists. Skipping sync_server process.")
+    # return
+
+    workfile_representation = next(
+        (
+            representation
+            for representation in get_representations(
+                project_name, versions_ids=[last_version_doc["_id"]]
+            )
+            if representation["context"]["task"]["name"] == task_name
+        ),
+        None,
+    )
+    if not workfile_representation:
+        print(
+            "No published workfilefor task '{}' and host '{}'.".format(
+                task_name, host_name
+            )
+        )
+        return
+
+    local_site_id = get_local_site_id()
+    sync_server.add_site(
+        project_name,
+        workfile_representation["_id"],
+        local_site_id,
+        force=True,
+        priority=99,
+        reset_timer=True,
+    )
+
+    while not sync_server.is_representation_on_site(
+        project_name, workfile_representation["_id"], local_site_id
+    ):
+        sleep(5)
+
+    new_workfile_path = version_up(last_workfile)
+
+    shutil.copy(
+        get_last_published_workfile_path(
+            host_name, project_name, asset_name, task_name
+        ),
+        new_workfile_path,
+    )
+
+    # Not sure yet if I should return a value or not
+    return new_workfile_path
+
+
 class SyncServerThread(threading.Thread):
     """
-        Separate thread running synchronization server with asyncio loop.
-        Stopped when tray is closed.
+    Separate thread running synchronization server with asyncio loop.
+    Stopped when tray is closed.
     """
+
     def __init__(self, module):
         self.log = Logger.get_logger(self.__class__.__name__)
 
@@ -258,9 +460,7 @@ class SyncServerThread(threading.Thread):
             self.log.info("Sync Server Started")
             self.loop.run_forever()
         except Exception:
-            self.log.warning(
-                "Sync Server service has failed", exc_info=True
-            )
+            self.log.warning("Sync Server service has failed", exc_info=True)
         finally:
             self.loop.close()  # optional
 
@@ -281,6 +481,7 @@ class SyncServerThread(threading.Thread):
         while self.is_running and not self.module.is_paused():
             try:
                 import time
+
                 start_time = time.time()
                 self.module.set_sync_project_settings()  # clean cache
                 project_name = None
@@ -293,9 +494,7 @@ class SyncServerThread(threading.Thread):
                         continue
 
                     sync_repres = self.module.get_sync_representations(
-                        project_name,
-                        local_site,
-                        remote_site
+                        project_name, local_site, remote_site
                     )
 
                     task_files_to_process = []
@@ -307,21 +506,24 @@ class SyncServerThread(threading.Thread):
                     # reuse same id
                     processed_file_path = set()
 
-                    site_preset = preset.get('sites')[remote_site]
-                    remote_provider = \
-                        self.module.get_provider_for_site(site=remote_site)
-                    handler = lib.factory.get_provider(remote_provider,
-                                                       project_name,
-                                                       remote_site,
-                                                       presets=site_preset)
+                    site_preset = preset.get("sites")[remote_site]
+                    remote_provider = self.module.get_provider_for_site(
+                        site=remote_site
+                    )
+                    handler = lib.factory.get_provider(
+                        remote_provider,
+                        project_name,
+                        remote_site,
+                        presets=site_preset,
+                    )
                     limit = lib.factory.get_provider_batch_limit(
-                        remote_provider)
+                        remote_provider
+                    )
                     # first call to get_provider could be expensive, its
                     # building folder tree structure in memory
                     # call only if needed, eg. DO_UPLOAD or DO_DOWNLOAD
                     for sync in sync_repres:
-                        if self.module.\
-                                is_representation_paused(sync['_id']):
+                        if self.module.is_representation_paused(sync["_id"]):
                             continue
                         if limit <= 0:
                             continue
@@ -329,74 +531,82 @@ class SyncServerThread(threading.Thread):
                         if files:
                             for file in files:
                                 # skip already processed files
-                                file_path = file.get('path', '')
+                                file_path = file.get("path", "")
                                 if file_path in processed_file_path:
                                     continue
                                 status = self.module.check_status(
                                     file,
                                     local_site,
                                     remote_site,
-                                    preset.get('config'))
+                                    preset.get("config"),
+                                )
                                 if status == SyncStatus.DO_UPLOAD:
                                     tree = handler.get_tree()
                                     limit -= 1
                                     task = asyncio.create_task(
-                                        upload(self.module,
-                                               project_name,
-                                               file,
-                                               sync,
-                                               remote_provider,
-                                               remote_site,
-                                               tree,
-                                               site_preset))
+                                        upload(
+                                            self.module,
+                                            project_name,
+                                            file,
+                                            sync,
+                                            remote_provider,
+                                            remote_site,
+                                            tree,
+                                            site_preset,
+                                        )
+                                    )
                                     task_files_to_process.append(task)
                                     # store info for exception handlingy
-                                    files_processed_info.append((file,
-                                                                 sync,
-                                                                 remote_site,
-                                                                 project_name
-                                                                 ))
+                                    files_processed_info.append(
+                                        (file, sync, remote_site, project_name)
+                                    )
                                     processed_file_path.add(file_path)
                                 if status == SyncStatus.DO_DOWNLOAD:
                                     tree = handler.get_tree()
                                     limit -= 1
                                     task = asyncio.create_task(
-                                        download(self.module,
-                                                 project_name,
-                                                 file,
-                                                 sync,
-                                                 remote_provider,
-                                                 remote_site,
-                                                 tree,
-                                                 site_preset))
+                                        download(
+                                            self.module,
+                                            project_name,
+                                            file,
+                                            sync,
+                                            remote_provider,
+                                            remote_site,
+                                            tree,
+                                            site_preset,
+                                        )
+                                    )
                                     task_files_to_process.append(task)
 
-                                    files_processed_info.append((file,
-                                                                 sync,
-                                                                 local_site,
-                                                                 project_name
-                                                                 ))
+                                    files_processed_info.append(
+                                        (file, sync, local_site, project_name)
+                                    )
                                     processed_file_path.add(file_path)
 
-                    self.log.debug("Sync tasks count {}".format(
-                        len(task_files_to_process)
-                    ))
+                    self.log.debug(
+                        "Sync tasks count {}".format(
+                            len(task_files_to_process)
+                        )
+                    )
                     files_created = await asyncio.gather(
-                        *task_files_to_process,
-                        return_exceptions=True)
-                    for file_id, info in zip(files_created,
-                                             files_processed_info):
+                        *task_files_to_process, return_exceptions=True
+                    )
+                    for file_id, info in zip(
+                        files_created, files_processed_info
+                    ):
                         file, representation, site, project_name = info
                         error = None
                         if isinstance(file_id, BaseException):
                             error = str(file_id)
                             file_id = None
-                        self.module.update_db(project_name,
-                                              file_id,
-                                              file,
-                                              representation,
-                                              site,
-                                              error)
+                        self.module.update_db(
+                            project_name,
+                            file_id,
+                            file,
+                            representation,
+                            site,
+                            error,
+                        )
 
                 duration = time.time() - start_time
                 self.log.debug("One loop took {:.2f}s".format(duration))
@@ -411,27 +621,30 @@ class SyncServerThread(threading.Thread):
             except ConnectionResetError:
                 self.log.warning(
                     "ConnectionResetError in sync loop, trying next loop",
-                    exc_info=True)
+                    exc_info=True,
+                )
             except CancelledError:
                 # just stopping server
                 pass
             except ResumableError:
                 self.log.warning(
                     "ResumableError in sync loop, trying next loop",
-                    exc_info=True)
+                    exc_info=True,
+                )
             except Exception:
                 self.stop()
                 self.log.warning(
                     "Unhandled except. in sync loop, stopping server",
-                    exc_info=True)
+                    exc_info=True,
+                )
 
     def stop(self):
         """Sets is_running flag to false, 'check_shutdown' shuts server down"""
         self.is_running = False
 
     async def check_shutdown(self):
-        """ Future that is running and checks if server should be running
-            periodically.
+        """Future that is running and checks if server should be running
+        periodically.
         """
         while self.is_running:
             if self.module.long_running_tasks:
@@ -441,12 +654,16 @@ class SyncServerThread(threading.Thread):
                 self.log.info("finished long running")
                 self.module.projects_processed.remove(task["project_name"])
             await asyncio.sleep(0.5)
-        tasks = [task for task in asyncio.all_tasks() if
-                 task is not asyncio.current_task()]
+        tasks = [
+            task
+            for task in asyncio.all_tasks()
+            if task is not asyncio.current_task()
+        ]
         list(map(lambda task: task.cancel(), tasks))  # cancel all the tasks
         results = await asyncio.gather(*tasks, return_exceptions=True)
         self.log.debug(
-            f'Finished awaiting cancelled tasks, results: {results}...')
+            f"Finished awaiting cancelled tasks, results: {results}..."
+        )
         await self.loop.shutdown_asyncgens()
         # to really make sure everything else has time to stop
         self.executor.shutdown(wait=True)
@@ -472,13 +689,15 @@ class SyncServerThread(threading.Thread):
         local_site = self.module.get_active_site(project_name)
         remote_site = self.module.get_remote_site(project_name)
         if local_site == remote_site:
-            self.log.debug("{}-{} sites same, skipping".format(
-                local_site, remote_site))
+            self.log.debug(
+                "{}-{} sites same, skipping".format(local_site, remote_site)
+            )
             return None, None
 
         configured_sites = _get_configured_sites(self.module, project_name)
-        if not all([local_site in configured_sites,
-                    remote_site in configured_sites]):
+        if not all(
+            [local_site in configured_sites, remote_site in configured_sites]
+        ):
             self.log.debug(
                 "Some of the sites {} - {} is not working properly".format(
                     local_site, remote_site

--- a/openpype/modules/sync_server/sync_server.py
+++ b/openpype/modules/sync_server/sync_server.py
@@ -29,11 +29,14 @@ async def upload(module, project_name, file, representation, provider_name,
         Source url is taken from 'file' portion, where {root} placeholder
         is replaced by 'representation.Context.root'
         Provider could be one of implemented in provider.py.
+
         Updates MongoDB, fills in id of file from provider (ie. file_id
         from GDrive), 'created_dt' - time of upload
+
         'provider_name' doesn't have to match to 'site_name', single
         provider (GDrive) might have multiple sites ('projectA',
         'projectB')
+
     Args:
         module(SyncServerModule): object to run SyncServerModule API
         project_name (str): source db
@@ -44,6 +47,7 @@ async def upload(module, project_name, file, representation, provider_name,
             have multiple sites (different accounts, credentials)
         tree (dictionary): injected memory structure for performance
         preset (dictionary): site config ('credentials_url', 'root'...)
+
     """
     # create ids sequentially, upload file in parallel later
     with module.lock:
@@ -97,6 +101,7 @@ async def download(module, project_name, file, representation, provider_name,
                    remote_site_name, tree=None, preset=None):
     """
         Downloads file to local folder denoted in representation.Context.
+
     Args:
         module(SyncServerModule): object to run SyncServerModule API
         project_name (str): source
@@ -107,6 +112,7 @@ async def download(module, project_name, file, representation, provider_name,
             have multiple sites (different accounts, credentials)
         tree (dictionary): injected memory structure for performance
         preset (dictionary): site config ('credentials_url', 'root'...)
+
         Returns:
         (string) - 'name' of local file
     """
@@ -151,7 +157,9 @@ def resolve_paths(module, file_path, project_name,
     """
         Returns tuple of local and remote file paths with {root}
         placeholders replaced with proper values from Settings or Anatomy
+
         Ejected here because of Python 2 hosts (GDriveHandler is an issue)
+
         Args:
             module(SyncServerModule): object to run SyncServerModule API
             file_path(string): path with {root}
@@ -175,7 +183,9 @@ def resolve_paths(module, file_path, project_name,
 def site_is_working(module, project_name, site_name):
     """
         Confirm that 'site_name' is configured correctly for 'project_name'.
+
         Must be here as lib.factory access doesn't work in Python 2 hosts.
+
         Args:
             module (SyncServerModule)
             project_name(string):
@@ -192,6 +202,7 @@ def _get_configured_sites(module, project_name):
     """
         Loops through settings and looks for configured sites and checks
         its handlers for particular 'project_name'.
+
         Args:
             project_setting(dict): dictionary from Settings
             only_project_name(string, optional): only interested in
@@ -227,7 +238,8 @@ def _get_configured_sites_from_setting(module, project_name, project_setting):
             configured_sites[site_name] = True
 
     return configured_sites
-    
+
+
 def get_last_published_workfile_path(
     host_name: str,
     project_name: str,
@@ -236,14 +248,12 @@ def get_last_published_workfile_path(
     anatomy: Anatomy = None,
 ) -> str:
     """Returns last published workfile path.
-
     Args:
         host_name (str): Host name.
         project_name (str): Project name.
         task_name (str): Task name.
         workfile_representation (dict): Workfile representation.
         anatomy (Anatomy, optional): Anatomy. Defaults to None.
-
     Returns:
         str: Last published workfile path.
     """
@@ -276,7 +286,6 @@ def download_last_published_workfile(
     asset_doc: dict = None,
 ) -> str:
     """Downloads the last pusblished workfile, and returns its path.
-
     Args:
         host_name (str): Host name.
         project_name (str): Project name.
@@ -289,7 +298,6 @@ def download_last_published_workfile(
         last_version_doc (dict): Last version doc.
         anatomy (Anatomy, optional): Anatomy. Defaults to None.
         asset_doc (dict, optional): Asset doc. Defaults to None.
-
     Returns:
         str: New local workfile path.
     """
@@ -445,6 +453,7 @@ class SyncServerThread(threading.Thread):
                 - update representations - fills error messages for exceptions
                 - waits X seconds and repeat
         Returns:
+
         """
         while self.is_running and not self.module.is_paused():
             try:

--- a/openpype/modules/sync_server/sync_server.py
+++ b/openpype/modules/sync_server/sync_server.py
@@ -8,6 +8,7 @@ from time import sleep
 from concurrent.futures._base import CancelledError
 
 from .providers import lib
+from openpype.client.entity_links import get_linked_representation_id
 from openpype.lib import Logger
 from openpype.lib.local_settings import get_local_site_id
 from openpype.modules.base import ModulesManager
@@ -54,7 +55,6 @@ async def upload(
             have multiple sites (different accounts, credentials)
         tree (dictionary): injected memory structure for performance
         preset (dictionary): site config ('credentials_url', 'root'...)
-
     """
     # create ids sequentially, upload file in parallel later
     with module.lock:
@@ -383,6 +383,12 @@ def download_last_published_workfile(
         reset_timer=True,
     )
 
+    representation_ids = {workfile_representation["_id"]}
+    representation_ids.update(
+        get_linked_representation_id(
+            project_name, repre_id=workfile_representation["_id"]
+        )
+    )
     for repre_id in representation_ids:
         sync_server.add_site(
             project_name,

--- a/openpype/modules/sync_server/sync_server.py
+++ b/openpype/modules/sync_server/sync_server.py
@@ -247,7 +247,7 @@ def get_last_published_workfile_path(
     workfile_representation: dict,
     anatomy: Anatomy = None,
 ) -> str:
-    """Returns last published workfile path.
+    """Get last published workfile path.
 
     Args:
         host_name (str): Host name.
@@ -265,7 +265,7 @@ def get_last_published_workfile_path(
 
     if not workfile_representation:
         print(
-            "No published workfilefor task '{}' and host '{}'.".format(
+            "No published workfile for task '{}' and host '{}'.".format(
                 task_name, host_name
             )
         )

--- a/openpype/modules/sync_server/sync_server.py
+++ b/openpype/modules/sync_server/sync_server.py
@@ -16,13 +16,7 @@ from openpype.pipeline.template_data import get_template_data_with_names
 from openpype.pipeline.load.utils import get_representation_path_with_anatomy
 from openpype.pipeline.workfile.path_resolving import get_workfile_template_key
 from openpype.settings.lib import get_project_settings
-from openpype.client.entities import (
-    get_last_version_by_subset_id,
-    get_representations,
-    get_subsets,
-    get_project,
-    get_asset_by_name,
-)
+from openpype.client.entities import get_asset_by_name
 
 from .utils import SyncStatus, ResumableError
 
@@ -280,20 +274,13 @@ def get_last_published_workfile_path(
     anatomy: Anatomy = None,
 ) -> str:
     """Returns last published workfile path.
-    Optional arguments can be filled as an optimisation.
 
     Args:
         host_name (str): Host name.
         project_name (str): Project name.
-        asset_name (str): Asset name.
         task_name (str): Task name.
+        workfile_representation (dict): Workfile representation.
         anatomy (Anatomy, optional): Anatomy. Defaults to None.
-        asset_doc (dict, optional): Asset dictionary. Defaults to None.
-        workfile_representation (dict, optional): Workfile representation.
-            Defaults to None.
-        subset_id (str, optional): Subset id. Defaults to None.
-        last_version_doc (dict, optional): Last version dictionary.
-            Defaults to None.
 
     Returns:
         str: Last published workfile path.
@@ -333,33 +320,54 @@ def download_last_published_workfile(
         project_name (str): Project name.
         asset_name (str): Asset name.
         task_name (str): Task name.
-        last_workfile (str, optional): Last (local) workfile path.
-            Defaults to None.
+        last_published_workfile_path (str): Last published workfile
+            path.
+        workfile_representation (dict): Workfile representation.
+        subset_id (str): Subset ID.
+        last_version_doc (dict): Last version doc.
+        anatomy (Anatomy, optional): Anatomy. Defaults to None.
+        asset_doc (dict, optional): Asset doc. Defaults to None.
 
     Returns:
-        str: _description_
+        str: New local workfile path.
     """
-    # TODO: Add availability check
+
     if not anatomy:
         anatomy = Anatomy(project_name)
 
     if not asset_doc:
         asset_doc = get_asset_by_name(project_name, asset_name)
 
-    modules_manager = ModulesManager()
-
-    sync_server = modules_manager.modules_by_name.get("sync_server")
+    # Getting sync server module
+    sync_server = ModulesManager().modules_by_name.get("sync_server")
     if not sync_server or not sync_server.enabled:
         print("Sync server module is disabled or unavailable.")
         return
 
-    if not subset_id:
-        print("Subset id not found for asset '{}'.".format(asset_doc["name"]))
+    if subset_id is None:
+        print(
+            "Not any matched subset for task '{}' of '{}'.".format(
+                task_name, asset_name
+            )
+        )
         return
 
     if not workfile_representation:
         print(
-            "No published workfilefor task '{}' and host '{}'.".format(
+            "Not published workfile for task '{}' and host '{}'.".format(
+                task_name, host_name
+            )
+        )
+        return
+
+    # If represenation isn't available on remote site, then return.
+    if not sync_server.is_representation_on_site(
+        project_name,
+        workfile_representation["_id"],
+        sync_server.get_remote_site(project_name),
+    ):
+        print(
+            "Representation for task '{}' and host '{}'".format(
                 task_name, host_name
             )
         )
@@ -375,79 +383,51 @@ def download_last_published_workfile(
         reset_timer=True,
     )
 
+    for repre_id in representation_ids:
+        sync_server.add_site(
+            project_name,
+            repre_id,
+            local_site_id,
+            force=True,
+            priority=99,
+            reset_timer=True,
+        )
+
+    # While representation unavailable locally, wait.
     while not sync_server.is_representation_on_site(
         project_name, workfile_representation["_id"], local_site_id
     ):
         sleep(5)
 
-    if not last_published_workfile_path:  # Check args
+    if not last_published_workfile_path:
         last_published_workfile_path = get_last_published_workfile_path(
             host_name,
             project_name,
-            asset_name,
             task_name,
+            workfile_representation,
             anatomy=anatomy,
-            asset_doc=asset_doc,
-            workfile_representation=workfile_representation,
-            subset_id=subset_id,
-            last_version_doc=last_version_doc,
         )
 
+    # Getting workfile data
     workfile_data = get_template_data_with_names(
         project_name, asset_name, task_name, host_name
     )
     workfile_data["version"] = last_version_doc["name"] + 1
     workfile_data["ext"] = last_published_workfile_path.split(".")[-1]
-    print(f"workfile ext: {workfile_data['ext']}")
+
     template_key = get_workfile_template_key(
         task_name, host_name, project_name, get_project_settings(project_name)
     )
     anatomy_result = anatomy.format(workfile_data)
     local_workfile_path = anatomy_result[template_key]["path"]
 
+    # Copy last published workfile to local workfile directory
     shutil.copy(
         last_published_workfile_path,
         local_workfile_path,
     )
 
     return local_workfile_path
-
-
-# /!\ Might be out of place!
-def get_subset_id(
-    project_name, asset_name, task_name, asset_doc
-):  # asset_name only for debug
-    filtered_subsets = [
-        subset
-        for subset in get_subsets(
-            project_name,
-            asset_ids=[asset_doc["_id"]],
-            fields=["_id", "name", "data.family", "data.families"],
-        )
-        if (
-            subset["data"].get("family") == "workfile"
-            # Legacy compatibility
-            or "workfile" in subset["data"].get("families", {})
-        )
-    ]
-    if not filtered_subsets:
-        print(
-            "Not any subset for asset '{}' with id '{}'.".format(
-                asset_name, asset_doc["_id"]
-            )
-        )
-        return
-
-    # Matching subset which has task name in its name
-    subset_id = None
-    low_task_name = task_name.lower()
-    if len(filtered_subsets) > 1:
-        for subset in filtered_subsets:
-            if low_task_name in subset["name"].lower():
-                subset_id = subset["_id"]
-                break
-
-    return subset_id
 
 
 class SyncServerThread(threading.Thread):


### PR DESCRIPTION
I moved the copy last workfile implementation to separate methods to make it reusable, so I can use it for another feature I'm developping without causing excessive redundancy.
Also added a check in case there is no representation available on remote site (as this causes OpenPype to freeze then crash)

There are four methods added for this:
`get_last_published_workfile` (sync_server.py)
`download_last_published_workfile` (sync_server.py)
`get_representation_by_task` (entity.py)
`match_subset_id` (entity.py)

To test:
Open a workfile which is available on remote site, but not active site.