### PR TITLE
feat: Add a render mode in extract playblast

### DIFF
--- a/openpype/hosts/blender/api/capture.py
+++ b/openpype/hosts/blender/api/capture.py
@@ -25,6 +25,7 @@ def capture(
     overwrite=False,
     image_settings=None,
     display_options=None,
+    render_mode=False,
 ):
     """Playblast in an independent windows
 
@@ -48,6 +49,8 @@ def capture(
         image_settings (dict, optional): Supplied image settings for render,
             using `ImageSettings`
         display_options (dict, optional): Supplied display options for render
+        render_mode (bool, optional):
+            Use render engine insted of openGL render. Default to False.
     """
 
     scene = bpy.context.scene
@@ -99,13 +102,10 @@ def capture(
         stack.enter_context(applied_image_settings(window, image_settings))
 
         with context_override(window=window):
-            bpy.ops.render.opengl(
-                animation=True,
-                render_keyed_only=False,
-                sequencer=False,
-                write_still=False,
-                view_context=True,
-            )
+            if render_mode:
+                bpy.ops.render.render(animation=True, use_viewport=True)
+            else:
+                bpy.ops.render.opengl(animation=True)
 
     return filename
 

--- a/openpype/hosts/blender/plugins/publish/collect_review.py
+++ b/openpype/hosts/blender/plugins/publish/collect_review.py
@@ -90,6 +90,7 @@ class CollectReview(pyblish.api.InstancePlugin):
                     "fps": instance.context.data["fps"],
                     "isolate": isolate_objects,
                     "audio": audio_tracks,
+                    "render_mode": instance.name.endswith("Render"),
                 }
             )
             instance.data["remove"] = True
@@ -107,6 +108,7 @@ class CollectReview(pyblish.api.InstancePlugin):
                     "fps": instance.context.data["fps"],
                     "isolate": isolate_objects,
                     "audio": audio_tracks,
+                    "render_mode": instance.name.endswith("Render"),
                 }
             )
             self.log.debug(f"instance data: {instance.data}")

--- a/openpype/hosts/blender/plugins/publish/extract_playblast.py
+++ b/openpype/hosts/blender/plugins/publish/extract_playblast.py
@@ -47,6 +47,9 @@ class ExtractPlayblast(openpype.api.Extractor):
         # get isolate objects list
         isolate = instance.data("isolate", None)
 
+        # get render mode
+        render_mode = instance.data.get("render_mode", False)
+
         # get ouput path
         stagingdir = self.staging_dir(instance)
         filename = instance.name
@@ -65,6 +68,7 @@ class ExtractPlayblast(openpype.api.Extractor):
                 "filename": path,
                 "overwrite": True,
                 "isolate": isolate,
+                "render_mode": render_mode,
             }
         )
         preset.setdefault(


### PR DESCRIPTION
## Brief description
Add a Render mode for the review to allow real rendering with the current render engine set in the blender scene settings instead of the openGL

## Testing notes:
1. Add a ReviewRender subset in shots or asset scene with render paramters
   (you can add a time limite per frame with Cycle to optimize render time)
2. publish the review (and be patient)