### PR TITLE
fix: create anim instances for occurences in build

### DIFF
--- a/openpype/hosts/blender/scripts/build_workfile.py
+++ b/openpype/hosts/blender/scripts/build_workfile.py
@@ -333,7 +333,6 @@ def build_anim(project_name, asset_name):
     bpy.ops.scene.make_container_publishable(container_name=cam_container.name)
 
     for obj in bpy.context.scene.objects:
-        # Select camera from cameraMain instance to link with the review.
         if obj.type == "ARMATURE":
             # Create animation instance
             variant_name = obj.name[obj.name.find("RIG_") + 4 :].capitalize()
@@ -343,6 +342,7 @@ def build_anim(project_name, asset_name):
                 subset_name=f"animation{variant_name}",
                 datapath="objects",
                 datablock_name=obj.name,
+                use_selection=False,
             )
 
     # Create review
@@ -352,6 +352,7 @@ def build_anim(project_name, asset_name):
         subset_name="reviewMain",
         datapath="collections",
         datablock_name=camera_collection.name,
+        use_selection=False,
     )
 
     # load the board mov as image background linked into the camera


### PR DESCRIPTION
## Brief description
Fix anim instances creation in build anim when occurences is in the layout casting.

## Note
This is a common issue with blender operators, we need to set all the arguments because default value doesn't seems to work as expected.