### PR TITLE
Feat: loader background image append audio in sequencer

### DIFF
--- a/openpype/hosts/blender/plugins/load/load_image.py
+++ b/openpype/hosts/blender/plugins/load/load_image.py
@@ -155,5 +155,12 @@ class BackgroundLoader(ImageLoader):
             bkg_img.image_user.frame_duration = (
                 bpy.context.scene.frame_end - bpy.context.scene.frame_start
             )
+            # Append audio in the sequencer
+            bpy.context.scene.sequence_editor.sequences.new_sound(
+                img.name,
+                img.filepath,
+                1,
+                bpy.context.scene.frame_start
+            )
 
         return container, datablocks


### PR DESCRIPTION
## Brief description
Audio from movieclip is append in sequencer when loading movie as background image for camera

## Testing notes:
Build layout from episode 104 should bring audio in the sequencer with correct timing.