### PR TITLE
Feature: build auto download subsets

### DIFF
--- a/openpype/hosts/blender/scripts/build_workfile.py
+++ b/openpype/hosts/blender/scripts/build_workfile.py
@@ -99,7 +99,7 @@ def wait_for_download(project_name, representations: List[dict]):
             for r in representations
             if r
         )
-        and time() - start < 60 * 5
+        and time() - start < 300
     ):
         sleep(5)
 

--- a/openpype/hosts/blender/scripts/build_workfile.py
+++ b/openpype/hosts/blender/scripts/build_workfile.py
@@ -88,7 +88,6 @@ def download_subset(
             project_name,
             repre_id,
             local_site_id,
-            force=True,
             priority=99,
         )
 

--- a/openpype/hosts/blender/scripts/build_workfile.py
+++ b/openpype/hosts/blender/scripts/build_workfile.py
@@ -77,6 +77,7 @@ def download_subset(
         representation["_id"],
         local_site_id,
         priority=99,
+        force=True,  # TODO meant to be removed when holding representation is fixed, see https://github.com/ynput/OpenPype/pull/4102
     )
 
     return representation
@@ -422,7 +423,9 @@ def build_anim(project_name, asset_name):
     """
     # Download not casting subsets
     layout_repre = download_subset(project_name, asset_name, "layoutMain")
-    board_repre = download_subset(project_name, asset_name, "BoardReference")
+    board_repre = download_subset(
+        project_name, asset_name, "BoardReference", "mov"
+    )
     camera_repre = download_subset(project_name, asset_name, "cameraMain")
     wait_for_download(project_name, [layout_repre, board_repre, camera_repre])
 

--- a/openpype/hosts/blender/scripts/build_workfile.py
+++ b/openpype/hosts/blender/scripts/build_workfile.py
@@ -105,7 +105,7 @@ def wait_for_download(project_name, representations: List[dict]):
 
 
 def load_subset(project_name, representation, loader_type=None):
-    """Load the representation of the last version of subset.
+    """Load the representation of the subset last version.
 
     Args:
         project_name (str): The project name.

--- a/openpype/hosts/blender/scripts/build_workfile.py
+++ b/openpype/hosts/blender/scripts/build_workfile.py
@@ -438,12 +438,18 @@ def build_anim(project_name, asset_name):
         asset_name (str):  The current asset name from OpenPype Session.
     """
     # Download not casting subsets
+    workfile_layout_repre = download_subset(
+        project_name, asset_name, "workfileLayout"
+    )
     layout_repre = download_subset(project_name, asset_name, "layoutMain")
     board_repre = download_subset(
         project_name, asset_name, "BoardReference", "mov"
     )
     camera_repre = download_subset(project_name, asset_name, "cameraMain")
-    wait_for_download(project_name, [layout_repre, board_repre, camera_repre])
+    wait_for_download(
+        project_name,
+        [workfile_layout_repre, layout_repre, board_repre, camera_repre],
+    )
 
     # Load layout subset
     layout_container, _layout_datablocks = load_subset(

--- a/openpype/hosts/blender/scripts/build_workfile.py
+++ b/openpype/hosts/blender/scripts/build_workfile.py
@@ -85,17 +85,16 @@ def download_subset(
     # Add local site to representations
     for repre_id in representation_ids:
         # Check if representation is already on site
-        if sync_server.is_representation_on_site(
+        if not sync_server.is_representation_on_site(
             project_name, repre_id, local_site_id
         ):
-            continue
-
-        sync_server.add_site(
-            project_name,
-            repre_id,
-            local_site_id,
-            priority=99,
-        )
+            sync_server.add_site(
+                project_name,
+                repre_id,
+                local_site_id,
+                priority=99,
+                force=True,
+            )
 
     return representation
 

--- a/openpype/hosts/blender/scripts/build_workfile.py
+++ b/openpype/hosts/blender/scripts/build_workfile.py
@@ -74,7 +74,6 @@ def download_subset(project_name, asset_name, subset_name, ext="blend"):
         project_name,
         representation["_id"],
         local_site_id,
-        force=True,
         priority=99,
     )
 

--- a/openpype/hosts/blender/scripts/build_workfile.py
+++ b/openpype/hosts/blender/scripts/build_workfile.py
@@ -125,7 +125,7 @@ def load_subset(project_name, representation, loader_type=None):
 def download_and_load_subset(
     project_name, asset_name, subset_name, loader_type=None
 ):
-    """Download and load the representation of the last version of subset.
+    """Download and load the representation of the subset last version.
 
     Args:
         project_name (str): The project name.

--- a/openpype/hosts/blender/scripts/build_workfile.py
+++ b/openpype/hosts/blender/scripts/build_workfile.py
@@ -23,7 +23,7 @@ from openpype.pipeline.create import get_legacy_creator_by_name
 
 
 def download_subset(project_name, asset_name, subset_name, ext="blend"):
-    """Download the representation of the last version of subset on current site.
+    """Download the representation of the subset last version on current site.
 
     Args:
         project_name (str): The project name.

--- a/openpype/hosts/blender/scripts/build_workfile.py
+++ b/openpype/hosts/blender/scripts/build_workfile.py
@@ -496,7 +496,7 @@ def build_anim(project_name, asset_name):
     )
 
     # load the board mov as image background linked into the camera
-    load_subset(project_name, board_repre, "Background", "mov")
+    load_subset(project_name, board_repre, "Background")
 
 
 def build_render(project_name, asset_name):

--- a/openpype/hosts/blender/scripts/build_workfile.py
+++ b/openpype/hosts/blender/scripts/build_workfile.py
@@ -84,6 +84,12 @@ def download_subset(
 
     # Add local site to representations
     for repre_id in representation_ids:
+        # Check if representation is already on site
+        if sync_server.is_representation_on_site(
+            project_name, repre_id, local_site_id
+        ):
+            continue
+
         sync_server.add_site(
             project_name,
             repre_id,


### PR DESCRIPTION
Ensures subsets are downloaded before loading them in three steps:
1. Tag subset for download
2. Wait for all downloads to be finished
3. Load downloaded subsets

Tested on `Layout` and `Animation` tasks.

## Testing notes:
1. Open any `Layout` or `Animation` and delete all dependencies from local cache.
2. Run `Build first workfile`
3. Required subsets must be downloaded and the build succeed 
