### PR TITLE
Fix make relative path exceptions

### DIFF
--- a/openpype/hosts/blender/utility_scripts/make_paths_relative.py
+++ b/openpype/hosts/blender/utility_scripts/make_paths_relative.py
@@ -11,19 +11,18 @@ if __name__ == "__main__":
         f"Blend file | All paths converted to relative: {bpy.data.filepath}"
     )
     # Resolve path from source filepath with the relative filepath
-    datablocks_with_filepath = [
-        datablock
-        for datablock in list(bpy.data.libraries) + list(bpy.data.images)
-        if not datablock.is_library_indirect
-    ]
-    for datablock in datablocks_with_filepath:
+    for datablock in list(bpy.data.libraries) + list(bpy.data.images):
         try:
-            if not datablock.filepath.startswith("//"):
+            if (
+                datablock
+                and not datablock.is_library_indirect
+                and datablock.filepath.startswith("//")
+            ):
                 datablock.filepath = bpy.path.relpath(
                     str(Path(datablock.filepath).resolve()),
                     start=str(Path(bpy.data.filepath).parent.resolve()),
                 )
-        except (RuntimeError, ValueError, OSError) as e:
+        except (RuntimeError, ReferenceError, ValueError, OSError) as e:
             log.error(e)
 
     bpy.ops.wm.save_mainfile()

--- a/openpype/hosts/blender/utility_scripts/make_paths_relative.py
+++ b/openpype/hosts/blender/utility_scripts/make_paths_relative.py
@@ -1,6 +1,7 @@
 """Make all paths relative."""
 
 from pathlib import Path
+from itertools import chain
 import bpy
 
 from openpype.lib.log import Logger
@@ -11,7 +12,7 @@ if __name__ == "__main__":
         f"Blend file | All paths converted to relative: {bpy.data.filepath}"
     )
     # Resolve path from source filepath with the relative filepath
-    for datablock in list(bpy.data.libraries) + list(bpy.data.images):
+    for datablock in chain(bpy.data.libraries, bpy.data.images):
         try:
             if (
                 datablock

--- a/openpype/hosts/blender/utility_scripts/make_paths_relative.py
+++ b/openpype/hosts/blender/utility_scripts/make_paths_relative.py
@@ -23,7 +23,7 @@ if __name__ == "__main__":
                     str(Path(datablock.filepath).resolve()),
                     start=str(Path(bpy.data.filepath).parent.resolve()),
                 )
-        except (RuntimeError, ValueError) as e:
+        except (RuntimeError, ValueError, OSError) as e:
             log.error(e)
 
     bpy.ops.wm.save_mainfile()

--- a/openpype/hosts/blender/utility_scripts/make_paths_relative.py
+++ b/openpype/hosts/blender/utility_scripts/make_paths_relative.py
@@ -16,7 +16,7 @@ if __name__ == "__main__":
             if (
                 datablock
                 and not datablock.is_library_indirect
-                and datablock.filepath.startswith("//")
+                and not datablock.filepath.startswith("//")
             ):
                 datablock.filepath = bpy.path.relpath(
                     str(Path(datablock.filepath).resolve()),


### PR DESCRIPTION
## Changelog Description
make relative path process can raise error outside try exception and won't execute `bpy.ops.wm.save_mainfile`
- added `ReferenceError `and `OSError`.
- for loops refactored in one inside try except statement.