### PR TITLE
Feature: Adding poselib family and text type

### DIFF
--- a/openpype/hosts/blender/api/utils.py
+++ b/openpype/hosts/blender/api/utils.py
@@ -23,6 +23,7 @@ BL_TYPE_DATAPATH = (  # TODO rename DATACOL
         bpy.types.Action: "actions",
         bpy.types.Armature: "armatures",
         bpy.types.Material: "materials",
+        bpy.types.Text: "texts",
     }
 )
 # Match Blender type to an ICON for display
@@ -33,6 +34,7 @@ BL_TYPE_ICON = {
     bpy.types.Action: "ACTION",
     bpy.types.Armature: "ARMATURE_DATA",
     bpy.types.Material: "MATERIAL_DATA",
+    bpy.types.Text: "TEXT",
 }
 # Types which can be handled through the outliner
 BL_OUTLINER_TYPES = frozenset((bpy.types.Collection, bpy.types.Object))

--- a/openpype/plugins/publish/integrate.py
+++ b/openpype/plugins/publish/integrate.py
@@ -132,7 +132,8 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
                 "mvUsdOverride",
                 "simpleUnrealTexture",
                 "online",
-                "uasset"
+                "uasset",
+                "blender.poselib",
                 ]
 
     default_template_name = "publish"


### PR DESCRIPTION
## Description
Adding `blender.poselib` to supported family list and adding `Text` type to blender host supported types.
These changes are necessary for the studio addon poselib features to work.