### PR TITLE
Fx thumbnail review tags

### DIFF
--- a/openpype/hosts/blender/plugins/publish/extract_playblast.py
+++ b/openpype/hosts/blender/plugins/publish/extract_playblast.py
@@ -3,10 +3,9 @@ import clique
 
 import bpy
 
-import pyblish.api
-
 from openpype.hosts.blender.api import capture
 from openpype.hosts.blender.api.lib import maintained_time
+from openpype.hosts.blender.plugins.publish import extract_thumbnail
 from openpype.pipeline.publish.publish_plugins import Extractor
 
 
@@ -22,7 +21,7 @@ class ExtractPlayblast(Extractor):
     hosts = ["blender"]
     families = ["review"]
     optional = True
-    order = pyblish.api.ExtractorOrder + 0.01
+    order = extract_thumbnail.ExtractThumbnail.order - 0.002
 
     def process(self, instance):
         self.log.info("Extracting capture..")

--- a/openpype/hosts/blender/plugins/publish/extract_thumbnail.py
+++ b/openpype/hosts/blender/plugins/publish/extract_thumbnail.py
@@ -118,17 +118,11 @@ class ExtractThumbnail(Extractor):
         tags = ["thumbnail", "review"]
 
         # Removed `review` tags from thumbnail if current subset instance
-        # already has a representation with `review` tag or if there is a
-        # `Review` subset in the current publish context.
+        # already has a representation with `review` tag.
         for repre in instance.data["representations"]:
             if "review" in repre.get("tags", []):
                 tags.remove("review")
                 break
-        else:
-            for context_instance in instance.context:
-                if context_instance.data.get("family") == "review":
-                    tags.remove("review")
-                    break
 
         representation = {
             "name": "thumbnail",

--- a/openpype/hosts/blender/plugins/publish/extract_thumbnail.py
+++ b/openpype/hosts/blender/plugins/publish/extract_thumbnail.py
@@ -20,7 +20,7 @@ class ExtractThumbnail(Extractor):
 
     label = "Extract Thumbnail"
     hosts = ["blender"]
-    families = ["review", "model", "rig"]
+    families = ["model", "rig"]
     order = pyblish.api.ExtractorOrder + 0.01
 
     def process(self, instance):

--- a/openpype/hosts/blender/plugins/publish/extract_thumbnail.py
+++ b/openpype/hosts/blender/plugins/publish/extract_thumbnail.py
@@ -116,10 +116,19 @@ class ExtractThumbnail(Extractor):
         instance.data.setdefault("representations", [])
 
         tags = ["thumbnail", "review"]
+
+        # Removed `review` tags from thumbnail if current subset instance
+        # already has a representation with `review` tag or if there is a
+        # `Review` subset in the current publish context.
         for repre in instance.data["representations"]:
             if "review" in repre.get("tags", []):
                 tags.remove("review")
                 break
+        else:
+            for context_instance in instance.context:
+                if context_instance.data.get("family") == "review":
+                    tags.remove("review")
+                    break
 
         representation = {
             "name": "thumbnail",

--- a/openpype/hosts/blender/plugins/publish/integrate_thumbnail.py
+++ b/openpype/hosts/blender/plugins/publish/integrate_thumbnail.py
@@ -7,4 +7,4 @@ class IntegrateThumbnails(integrate_thumbnail.IntegrateThumbnails):
 
     label = "Integrate Thumbnails"
     order = pyblish.api.IntegratorOrder + 0.01
-    families = ["review", "model", "rig"]
+    families = ["model", "rig"]


### PR DESCRIPTION
## Changelog Description
Extra thumbnails are push in Kitsu as review. The only case we want thumbnail as Kitsu review is when there are no review subset published.

- set `extract_layblast` order relative to `extract_thumbnail`: review subsets should always be registered before thumbnail.
- <s>`'review'` tag are remove from thumbnail when publishing context contain a review family subset. </s>
- thumbnail are disable for review family subset.

## Note
We need more tag filter with `integrated_kitsu_review` before allowed thumbnail for review (actually not useful as much)
- See filters from ftrack : https://github.com/ynput/OpenPype/blob/develop/openpype/modules/ftrack/plugins/publish/integrate_ftrack_instances.py#L123