### PR TITLE
Feat: Create animation instance for all animated objects

### DIFF
--- a/openpype/hosts/blender/scripts/build_workfile.py
+++ b/openpype/hosts/blender/scripts/build_workfile.py
@@ -793,7 +793,7 @@ def build_anim(project_name, asset_name):
                     add_datablocks_to_container(
                         obj, container_animation_instance
                     )
-                animated_objects.remove(obj)
+            animated_objects -= container_objects
         # Create animation instance for remaining animated object.
         for obj in animated_objects:
             variant_name = obj.name[0].upper() + obj.name[1:]

--- a/openpype/hosts/blender/scripts/build_workfile.py
+++ b/openpype/hosts/blender/scripts/build_workfile.py
@@ -16,6 +16,7 @@ from openpype.client.entities import (
     get_version_by_id,
 )
 from openpype.hosts.blender.api.properties import OpenpypeContainer
+from openpype.hosts.blender.api.lib import add_datablocks_to_container
 from openpype.hosts.blender.api.lib import update_scene_containers
 from openpype.lib.local_settings import get_local_site_id
 from openpype.modules import ModulesManager
@@ -774,15 +775,24 @@ def build_anim(project_name, asset_name):
                 else container.name[1:]
             )
             # Create animation instance for animated object from container.
+            container_animation_instance = None
             for obj in container_objects & animated_objects:
-                bpy.ops.scene.create_openpype_instance(
-                    creator_name="CreateAnimation",
-                    asset_name=asset_name,
-                    subset_name=f"animation{variant_name}",
-                    datapath="objects",
-                    datablock_name=obj.name,
-                    use_selection=False,
-                )
+                if container_animation_instance is None:
+                    bpy.ops.scene.create_openpype_instance(
+                        creator_name="CreateAnimation",
+                        asset_name=asset_name,
+                        subset_name=f"animation{variant_name}",
+                        datapath="objects",
+                        datablock_name=obj.name,
+                        use_selection=False,
+                    )
+                    container_animation_instance = (
+                        bpy.context.scene.openpype_instances[-1]
+                    )
+                else:
+                    add_datablocks_to_container(
+                        obj, container_animation_instance
+                    )
                 animated_objects.remove(obj)
         # Create animation instance for remaining animated object.
         for obj in animated_objects:


### PR DESCRIPTION
## Changelog Description
Added animation instance creation for animated objects (non-armature)
- create an instance animation per setdress and collect all animated objects from this container.
- create a simple animation for remaining animated objects.

# Additionnal fix
- varient name refactor without `capitalize()` to keep all upper case : `chouchou_MD` > `Chouchou_MD`