### PR TITLE
fix build errors with more conditions

### DIFF
--- a/openpype/hosts/blender/scripts/build_workfile.py
+++ b/openpype/hosts/blender/scripts/build_workfile.py
@@ -317,7 +317,7 @@ def build_model(project_name, asset_name):
     create_instance("CreateModel", "modelMain", useSelection=True)
     # load the concept reference as image reference in the scene.
     download_and_load_subset(
-        project_name, asset_name, "conceptReference", "Reference"
+        project_name, asset_name, "ConceptReference", "Reference"
     )
 
 


### PR DESCRIPTION
## Changelog Description
Fix stuck build errors.
- Argument `loader_type` from `get_loader` and `download_and_load_subset` is no more optional.
- Switch hero dont fail if some representation doesn't have loader metadata
- load casting in layout don't fail with link and unlink collection
