### PR TITLE
Fix: Build lipsync workfile too many arg error

### DIFF
--- a/openpype/hosts/blender/scripts/build_workfile.py
+++ b/openpype/hosts/blender/scripts/build_workfile.py
@@ -866,7 +866,6 @@ def build_lipsync(project_name: str, shot_name: str):
             load_subset(
                 project_name,
                 representation,
-                "rigMain",
                 "LinkRigLoader",
             )
         else:


### PR DESCRIPTION
## Changelog Description
Small fix for an error occuring when `load_subset` is called in `build_lipsync` method, stating too many arguments were given. Most likely due to `load_subset` being changed since `build_lipsync` was merged.

## Testing notes:
Build any lipsync workfile.