### PR TITLE
Fix: Image and audio datablocks tagged for container auto creation

### DIFF
--- a/openpype/hosts/blender/api/lib.py
+++ b/openpype/hosts/blender/api/lib.py
@@ -169,6 +169,8 @@ def update_scene_containers() -> List[OpenpypeContainer]:
         if (
             entity in datablocks_to_skip
             or user_map.get(entity) <= datablocks_to_skip
+            if user_map.get(entity)
+            else False
         ):
             continue
 

--- a/openpype/hosts/blender/api/lib.py
+++ b/openpype/hosts/blender/api/lib.py
@@ -166,11 +166,8 @@ def update_scene_containers() -> List[OpenpypeContainer]:
     created_containers = {c.name: c for c in openpype_containers}
     user_map = bpy.data.user_map(subset=containerized_datablocks)
     for entity in containerized_datablocks:
-        if (
-            entity in datablocks_to_skip
-            or user_map.get(entity) <= datablocks_to_skip
-            if user_map.get(entity)
-            else False
+        if entity in datablocks_to_skip or (
+            user_map.get(entity) and user_map.get(entity) <= datablocks_to_skip
         ):
             continue
 

--- a/openpype/hosts/blender/plugins/load/load_audio.py
+++ b/openpype/hosts/blender/plugins/load/load_audio.py
@@ -68,10 +68,9 @@ class AudioLoader(plugin.AssetLoader):
         auto creation of theses datablocks.
         """
         container, datablocks = super().load(*args, **kwargs)
-        sound = datablocks[0]
 
         # Set container metadata to sound datablock
-        sound[AVALON_PROPERTY] = container.get(AVALON_PROPERTY)
+        datablocks[0][AVALON_PROPERTY] = container.get(AVALON_PROPERTY)
 
         return container, datablocks
 

--- a/openpype/hosts/blender/plugins/load/load_audio.py
+++ b/openpype/hosts/blender/plugins/load/load_audio.py
@@ -7,6 +7,7 @@ import bpy
 
 from openpype.hosts.blender.api import plugin
 from openpype.hosts.blender.api.properties import OpenpypeContainer
+from openpype.hosts.blender.api.utils import AVALON_PROPERTY
 
 
 class AudioLoader(plugin.AssetLoader):
@@ -60,6 +61,20 @@ class AudioLoader(plugin.AssetLoader):
 
         return container, datablocks
 
+    def load(self, *args, **kwargs):
+        """OVERRIDE.
+
+        Keep container metadata in sound datablock to allow container
+        auto creation of theses datablocks.
+        """
+        container, datablocks = super().load(*args, **kwargs)
+        sound = datablocks[0]
+
+        # Set container metadata to sound datablock
+        sound[AVALON_PROPERTY] = container.get(AVALON_PROPERTY)
+
+        return container, datablocks
+
     def update(
         self, *args, **kwargs
     ) -> Tuple[OpenpypeContainer, List[bpy.types.ID]]:
@@ -76,6 +91,10 @@ class AudioLoader(plugin.AssetLoader):
         container, datablocks = super().update(
             container_metadata, representation
         )
+
+        # Set container metadata to sound datablock
+        sound = datablocks[0]
+        sound[AVALON_PROPERTY] = container.get(AVALON_PROPERTY)
 
         return container, datablocks
 

--- a/openpype/hosts/blender/plugins/load/load_image.py
+++ b/openpype/hosts/blender/plugins/load/load_image.py
@@ -67,10 +67,9 @@ class ImageLoader(plugin.AssetLoader):
         auto creation of theses datablocks.
         """
         container, datablocks = super().load(*args, **kwargs)
-        img = datablocks[0]
 
         # Set container metadata to image datablock
-        img[AVALON_PROPERTY] = container.get(AVALON_PROPERTY)
+        datablocks[0][AVALON_PROPERTY] = container.get(AVALON_PROPERTY)
 
         return container, datablocks
 


### PR DESCRIPTION
## Changelog Description
Image and audio datablocks weren't configured appropriately to allow the container auto creation identifying them.

## Testing notes:
1. Open any empty task (ie `Board` of `e104_sh029`)
2. Load `BoardReference` and `AudioReference` of a shot (`e104_sh029`)
3. Run `C.scene.openpype_containers.clear()`
4. Open Manage
