### PR TITLE
Fix: Containerized datablocks collected locally

### DIFF
--- a/openpype/hosts/blender/plugins/publish/extract_blend.py
+++ b/openpype/hosts/blender/plugins/publish/extract_blend.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import List, Set, Tuple
 
 import bpy
+from openpype.hosts.blender.api.utils import AVALON_PROPERTY
 
 from openpype.pipeline import (
     legacy_io,
@@ -185,6 +186,7 @@ class ExtractBlend(publish.Extractor):
             for img in images
             if img.source in {"FILE", "SEQUENCE", "MOVIE"}
             and not img.packed_file
+            and not img.get(AVALON_PROPERTY)
         }:
             # Skip image from library or internal
             if image.library or not image.filepath:


### PR DESCRIPTION
## Changelog Description
:warning: Based on #46 

Containerized datablocks are collected locally into the `resources` directory, which is not relevant. Datablocks from OpenPype must remain at a single location and not moved with the workfile.

## Testing notes:
1. Open an empty workfile (is `e666_sh001`)
1. Load a board reference 
2. Publish
3. Check into published directory: the mov hasn't been copied
4. Remove your local workfile
5. Launch the task for auto dl
6. It opens with the path mapped to the appropriate OP's location.
