### PR TITLE
Fix: Error gdeformer collection when character isn't in scene at build

### DIFF
--- a/openpype/hosts/blender/scripts/build_workfile.py
+++ b/openpype/hosts/blender/scripts/build_workfile.py
@@ -418,18 +418,26 @@ def create_gdeformer_collection(parent_collection: bpy.types.Collection):
     Args:
         parent_collection (bpy.types.Collection): Collection to create GDEFORMER col in
     """
-    # Create GDEFORMER collection
-    gdeformer_col = bpy.data.collections.new("GDEFORMER")
-    parent_collection.children.link(gdeformer_col)
+
+    # Check if there are GDEFORM objects
+    gdeform_check = False
     for obj in bpy.context.scene.objects:
         if obj.name.startswith("GDEFORM"):
-            gdeformer_col.objects.link(obj)
+            gdeform_check = True
 
-        # Assign collection to sol(s) object(s)
-        if obj.name.lower().startswith("sol") and obj.modifiers.get(
-            "GroundDeform"
-        ):
-            obj.modifiers["GroundDeform"]["Input_2"] = gdeformer_col
+    # Create GDEFORMER collection
+    if gdeform_check:
+        gdeformer_col = bpy.data.collections.new("GDEFORMER")
+        parent_collection.children.link(gdeformer_col)
+        for obj in bpy.context.scene.objects:
+            if obj.name.startswith("GDEFORM"):
+                gdeformer_col.objects.link(obj)
+
+            # Assign collection to sol(s) object(s)
+            if obj.name.lower().startswith("sol") and obj.modifiers.get(
+                "GroundDeform"
+            ):
+                obj.modifiers["GroundDeform"]["Input_2"] = gdeformer_col
 
 
 def build_layout(project_name, asset_name):

--- a/openpype/hosts/blender/scripts/build_workfile.py
+++ b/openpype/hosts/blender/scripts/build_workfile.py
@@ -419,25 +419,20 @@ def create_gdeformer_collection(parent_collection: bpy.types.Collection):
         parent_collection (bpy.types.Collection): Collection to create GDEFORMER col in
     """
 
-    # Check if there are GDEFORM objects
-    gdeform_check = False
+    # Create GDEFORMER Collection
+    gdeformer_col = None
     for obj in bpy.context.scene.objects:
         if obj.name.startswith("GDEFORM"):
-            gdeform_check = True
+            if not gdeformer_col:
+                gdeformer_col = bpy.data.collections.new("GDEFORMER")
+                parent_collection.children.link(gdeformer_col)
+            gdeformer_col.objects.link(obj)
 
-    # Create GDEFORMER collection
-    if gdeform_check:
-        gdeformer_col = bpy.data.collections.new("GDEFORMER")
-        parent_collection.children.link(gdeformer_col)
-        for obj in bpy.context.scene.objects:
-            if obj.name.startswith("GDEFORM"):
-                gdeformer_col.objects.link(obj)
-
-            # Assign collection to sol(s) object(s)
-            if obj.name.lower().startswith("sol") and obj.modifiers.get(
-                "GroundDeform"
-            ):
-                obj.modifiers["GroundDeform"]["Input_2"] = gdeformer_col
+        # Assign collection to sol(s) object(s)
+        if obj.name.lower().startswith("sol") and obj.modifiers.get(
+            "GroundDeform"
+        ):
+            obj.modifiers["GroundDeform"]["Input_2"] = gdeformer_col
 
 
 def build_layout(project_name, asset_name):

--- a/openpype/hosts/blender/scripts/build_workfile.py
+++ b/openpype/hosts/blender/scripts/build_workfile.py
@@ -419,15 +419,15 @@ def create_gdeformer_collection(parent_collection: bpy.types.Collection):
         parent_collection (bpy.types.Collection): Collection to create GDEFORMER col in
     """
 
-    # Create GDEFORMER Collection
+    # Create and populate GDEFORMER Collection
     gdeformer_col = None
     for obj in bpy.context.scene.objects:
         if obj.name.startswith("GDEFORM"):
-            # Check if the GDEFORMER collection exists to create it and link it to the parent collection in args only once
+            # Create GDEFORMER collection at first loop
             if not gdeformer_col:
                 gdeformer_col = bpy.data.collections.new("GDEFORMER")
                 parent_collection.children.link(gdeformer_col)
-            # Link GDEFORM objects to the GDEFORMER collection
+            # Link object to the GDEFORMER collection
             gdeformer_col.objects.link(obj)
 
         # Assign collection to sol(s) object(s)

--- a/openpype/hosts/blender/scripts/build_workfile.py
+++ b/openpype/hosts/blender/scripts/build_workfile.py
@@ -423,9 +423,11 @@ def create_gdeformer_collection(parent_collection: bpy.types.Collection):
     gdeformer_col = None
     for obj in bpy.context.scene.objects:
         if obj.name.startswith("GDEFORM"):
+            # Check if the GDEFORMER collection exists to create it and link it to the parent collection in args only once
             if not gdeformer_col:
                 gdeformer_col = bpy.data.collections.new("GDEFORMER")
                 parent_collection.children.link(gdeformer_col)
+            # Link GDEFORM objects to the GDEFORMER collection
             gdeformer_col.objects.link(obj)
 
         # Assign collection to sol(s) object(s)


### PR DESCRIPTION
## Changelog Description
Fix an issue on the openpype build first workfile. Will not create a GDEFORM collection if there are no character with GDEFORM in the built scene.

## Testing notes:
1. Open a blender scene with openpype (ex: e101sq002sh004 with character / e101sq004sh014 without character)
2. In the openpype menu click on "Build First Workfile"
3. Check if the GDEFORM collection is here :
- If the scene got a character --> The GDEFORM collection should be in the outliner with all GDEFORM objects linked
- If the scene got no character --> There's no GDEFORM collection