### PR TITLE
Enhancement: build layout load audio before board

### DIFF
--- a/openpype/hosts/blender/api/ops.py
+++ b/openpype/hosts/blender/api/ops.py
@@ -1021,9 +1021,9 @@ class BuildWorkFile(bpy.types.Operator):
 
     def _build_first_workfile(self, clear_scene: bool, save_as: bool):
         """Execute Build First workfile process.
-        
+
         Args:
-            clear_scene (bool): Clear scene content before the build. 
+            clear_scene (bool): Clear scene content before the build.
             save_as (bool): Save as new incremented workfile after the build.
         """
         if clear_scene:
@@ -1037,6 +1037,9 @@ class BuildWorkFile(bpy.types.Operator):
                 bpy.data.objects.remove(obj)
             for collection in set(bpy.data.collections):
                 bpy.data.collections.remove(collection)
+            # clear sequencer
+            for seq in bpy.context.scene.sequence_editor.sequences:
+                bpy.context.scene.sequence_editor.sequences.remove(seq)
             # purgne unused datablock
             while bpy.data.orphans_purge(
                 do_local_ids=False, do_recursive=True

--- a/openpype/hosts/blender/scripts/build_workfile.py
+++ b/openpype/hosts/blender/scripts/build_workfile.py
@@ -342,26 +342,21 @@ def load_references(
     """
     errors = []
 
-    # load the board mov as image background linked into the camera
-    if board_repre:
-        load_subset(project_name, board_repre, "Background")
-    else:
-        errors.append(
-            "load subset BoardReference failed:"
-            f" Missing subset for {asset_name}"
-        )
-
-    # Delete sound sequence from board mov
-    if len(bpy.context.scene.sequence_editor.sequences) > 0:
-        if sound_seq := bpy.context.scene.sequence_editor.sequences[-1]:
-            bpy.context.scene.sequence_editor.sequences.remove(sound_seq)
-
     # load the audio reference as sound into sequencer
     if audio_repre:
         load_subset(project_name, audio_repre, "Audio")
     else:
         errors.append(
             "load subset AudioReference failed:"
+            f" Missing subset for {asset_name}"
+        )
+
+    # load the board mov as image background linked into the camera
+    if board_repre:
+        load_subset(project_name, board_repre, "Background")
+    else:
+        errors.append(
+            "load subset BoardReference failed:"
             f" Missing subset for {asset_name}"
         )
 


### PR DESCRIPTION
## Changelog Description
Since https://github.com/Tilix4/OpenPype/pull/52 loading board don't add extra audio so audio ref should be added first

## Additional change
- `clear_scene` option forbuild first workfile clear sequencer
