### PR TITLE
FIX: worlds not clear on build when 'clear current scene' checked

### DIFF
--- a/openpype/hosts/blender/api/ops.py
+++ b/openpype/hosts/blender/api/ops.py
@@ -1048,6 +1048,9 @@ class BuildWorkFile(bpy.types.Operator):
             # clear all libraries
             for library in list(bpy.data.libraries):
                 bpy.data.libraries.remove(library)
+            # Clear all worlds
+            for world in bpy.data.worlds:
+                bpy.data.worlds.remove(world)
 
         print("Build Workfile")
         build_workfile()

--- a/openpype/hosts/blender/api/ops.py
+++ b/openpype/hosts/blender/api/ops.py
@@ -1046,7 +1046,7 @@ class BuildWorkFile(bpy.types.Operator):
             ):
                 pass
             # clear all libraries
-            for library in list(bpy.data.libraries):
+            for library in bpy.data.libraries:
                 bpy.data.libraries.remove(library)
             # Clear all worlds
             for world in bpy.data.worlds:


### PR DESCRIPTION
## Description
Remove the worlds when `clear_current_scene` is checked.

## Testing:
1. Launch a scene from Woollywoolly
2. Try a build with `clear current scene` checked 
3. You should get the behavior described above
