### PR TITLE
Change: Build Audio and Board references as hero

### DIFF
--- a/openpype/hosts/blender/scripts/build_workfile.py
+++ b/openpype/hosts/blender/scripts/build_workfile.py
@@ -446,10 +446,10 @@ def build_layout(project_name, asset_name):
     """
     # Download not casting subsets
     board_repre = download_subset(
-        project_name, asset_name, "BoardReference", "mov"
+        project_name, asset_name, "BoardReference", "mov", hero=True
     )
     audio_repre = download_subset(
-        project_name, asset_name, "AudioReference", "wav"
+        project_name, asset_name, "AudioReference", "wav", hero=True
     )
 
     # Create layout instance
@@ -606,10 +606,10 @@ def build_anim(project_name, asset_name):
     )
     layout_repre = download_subset(project_name, asset_name, "layoutMain")
     board_repre = download_subset(
-        project_name, asset_name, "BoardReference", "mov"
+        project_name, asset_name, "BoardReference", "mov", hero=True
     )
     audio_repre = download_subset(
-        project_name, asset_name, "AudioReference", "wav"
+        project_name, asset_name, "AudioReference", "wav", hero=True
     )
     camera_repre = download_subset(project_name, asset_name, "cameraMain")
     wait_for_download(


### PR DESCRIPTION
## Changelog Description
It's been decided with anim and layout teams that Audio and Board References must be loaded as hero to avoid having to update by hand if a new version has been published.

## Testing notes:
1. Merge on last release
2. Build `e666_sh005` layout
3. Publish layout and camera
4. Build anim
