### PR TITLE
Bugfix: Build first workfile save as

### DIFF
--- a/openpype/hosts/blender/api/ops.py
+++ b/openpype/hosts/blender/api/ops.py
@@ -1075,8 +1075,11 @@ class BuildWorkFile(bpy.types.Operator):
                 data.update({"version": 0, "ext": "blend"})
 
                 # Getting file name anatomy
-                anatomy_filled = Anatomy(project_name).format(data)
-                file_path = anatomy_filled["work"]["file"]
+                file_path = (
+                    bpy.data.filepath
+                    if bpy.data.filepath
+                    else Anatomy(project_name).format(data)["work"]["file"]
+                )
 
                 # Saving
                 if file_path:

--- a/openpype/hosts/blender/api/ops.py
+++ b/openpype/hosts/blender/api/ops.py
@@ -1077,8 +1077,7 @@ class BuildWorkFile(bpy.types.Operator):
                 # Getting file name anatomy
                 file_path = (
                     bpy.data.filepath
-                    if bpy.data.filepath
-                    else Anatomy(project_name).format(data)["work"]["file"]
+                    or Anatomy(project_name).format(data)["work"]["file"]
                 )
 
                 # Saving

--- a/openpype/hosts/blender/scripts/build_workfile.py
+++ b/openpype/hosts/blender/scripts/build_workfile.py
@@ -1094,10 +1094,6 @@ def build_workfile():
     else:
         return False
 
-    # Auto save
-    if bpy.data.filepath:
-        bpy.ops.wm.save_mainfile()
-
     return True
 
 


### PR DESCRIPTION
## Changelog Description
Fixing two bugs related to the `Save as...` option in the `Build First Workfile` feature:
- Blender file saved even if saved as is ticked off if the opened file has been saved (and overwrites currently opened file).
- Workfile isn't incremented if `Save as...` is ticked on (and v001 is overwritten).

## Testing notes:
1. Open any layout or animation workfile.
2. Build first workfile with `Save as...` ticked off.
3. Workfile should not be saved
4. Build workfile with `Save as...` ticked on.
5. Workfile should be saved and incremented.