### PR TITLE
Bugfix: Safer build first workfile save as

### DIFF
--- a/openpype/hosts/blender/api/ops.py
+++ b/openpype/hosts/blender/api/ops.py
@@ -1076,19 +1076,23 @@ class BuildWorkFile(bpy.types.Operator):
                 data = get_template_data_with_names(
                     project_name, asset_name, task_name, host_name
                 )
-                data.update({
-                    "version": get_last_workfile_with_version(
-                        root,
-                        Anatomy(project_name).templates[
-                            get_workfile_template_key(
-                                task_name, host_name, project_name,
-                            )
-                        ]["file"],
-                        data,
-                        ["blend"],
-                    )[1],
-                    "ext": "blend",
-                })
+                data.update(
+                    {
+                        "version": get_last_workfile_with_version(
+                            root,
+                            Anatomy(project_name).templates[
+                                get_workfile_template_key(
+                                    task_name,
+                                    host_name,
+                                    project_name,
+                                )
+                            ]["file"],
+                            data,
+                            ["blend"],
+                        )[1],
+                        "ext": "blend",
+                    }
+                )
 
                 # Getting file name anatomy
                 file_path = (

--- a/openpype/hosts/blender/api/ops.py
+++ b/openpype/hosts/blender/api/ops.py
@@ -40,6 +40,10 @@ from openpype.pipeline.create.creator_plugins import (
 )
 from openpype.pipeline.create.subset_name import get_subset_name
 from openpype.pipeline.template_data import get_template_data_with_names
+from openpype.pipeline.workfile import (
+    get_last_workfile_with_version,
+    get_workfile_template_key,
+)
 from openpype.lib.path_tools import version_up
 from openpype.tools.utils import host_tools
 from openpype.hosts.blender.scripts import build_workfile
@@ -1072,7 +1076,19 @@ class BuildWorkFile(bpy.types.Operator):
                 data = get_template_data_with_names(
                     project_name, asset_name, task_name, host_name
                 )
-                data.update({"version": 0, "ext": "blend"})
+                data.update({
+                    "version": get_last_workfile_with_version(
+                        root,
+                        Anatomy(project_name).templates[
+                            get_workfile_template_key(
+                                task_name, host_name, project_name,
+                            )
+                        ]["file"],
+                        data,
+                        ["blend"],
+                    )[1],
+                    "ext": "blend",
+                })
 
                 # Getting file name anatomy
                 file_path = (


### PR DESCRIPTION
## Changelog Description
Fixing two cases that could cause accidental overwrite of existing local workfiles while building first workfile with `Save as` ticked on:
- If there are existing local workfiles but the user created a new unsaved blend file before building first workfile with `Save as ticked on.
- If the user rollbacked to a previous local workfile before building first workfile with `Save as` ticked on.

## Testing notes:
- Open any layout or animation workfile.
- Build first workfile with `Save as` ticked on.
- Create new blend file and don't save it.
- Build first workfile with `Save as` ticked on.
- Open a previous workfile.
- Build first workfile with `Save as` ticked on.
- At each build, the new workfile version number should be incremented to be the latest, and no existing workfile should be overwritten.