### PR TITLE
Fix: build first workfile save as - no workfile or no workfile directory.

### DIFF
--- a/openpype/hosts/blender/api/ops.py
+++ b/openpype/hosts/blender/api/ops.py
@@ -1065,7 +1065,9 @@ class BuildWorkFile(bpy.types.Operator):
 
             with qt_app_context():
                 session = legacy_io.Session
-                root = work_root(session)
+                root = Path(work_root(session))
+                if not root.is_dir():
+                    root.mkdir()
 
                 # Set work file data for template formatting
                 project_name = session["AVALON_PROJECT"]
@@ -1079,7 +1081,7 @@ class BuildWorkFile(bpy.types.Operator):
                 data.update(
                     {
                         "version": get_last_workfile_with_version(
-                            root,
+                            root.as_posix(),
                             Anatomy(project_name).templates[
                                 get_workfile_template_key(
                                     task_name,
@@ -1089,7 +1091,8 @@ class BuildWorkFile(bpy.types.Operator):
                             ]["file"],
                             data,
                             ["blend"],
-                        )[1],
+                        )[1]
+                        or 0,
                         "ext": "blend",
                     }
                 )
@@ -1102,7 +1105,7 @@ class BuildWorkFile(bpy.types.Operator):
 
                 # Saving
                 if file_path:
-                    file_path = version_up(os.path.join(root, file_path))
+                    file_path = version_up(root.joinpath(file_path).as_posix())
                     save_file(file_path, copy=False)
                 else:
                     print("Failed to save")


### PR DESCRIPTION
## Changelog Description
In my attempt to fix bugs related to the `save as` feature of the build first workfile, I overlooked the fact that it broke these common cases:
- Build first workfile with `save as` ticked on when no workfile is locally available.
- Build first workfile with `save as` ticked on when the local workfile directory (`Fabrication`, `Layout` `Animation`) has not been created.

## Testing notes:
- Open any asset while ensuring there will be no local workfile and no local workfile directory (A good way to do that even on an asset with published workfile is to right click blender (in the launcher), tick `Skip opening last workfile.` and once blender opens, remove the workfile directory)
- Build first workfile with `save as` ticked on.
- Feel free to test other cases to ensure they still work.