### PR TITLE
fix: remove animation check to enable instances by default

### DIFF
--- a/openpype/hosts/blender/scripts/build_workfile.py
+++ b/openpype/hosts/blender/scripts/build_workfile.py
@@ -851,20 +851,6 @@ def build_anim(project_name, asset_name):
         animation_instance = bpy.context.scene.openpype_instances[-1]
         add_datablocks_to_container(objects[1:], animation_instance)
 
-        # Enabled instance for publishing if any member objects are animated.
-        publish_enabled = False
-        for obj in objects:
-            if (
-                isinstance(obj, bpy.types.Object)
-                and obj.animation_data
-                and obj.animation_data.action
-            ):
-                publish_enabled = True
-                break
-            elif isinstance(obj, bpy.types.Collection):
-                objects.extend(obj.all_objects)
-        animation_instance.publish = publish_enabled
-
     # load the audio reference as sound into sequencer
     if audio_repre:
         load_subset(project_name, audio_repre, "Audio")
@@ -1043,6 +1029,7 @@ def build_fabrication(project_name: str, asset_name: str):
         "render_preset"
     )
     apply_settings(bpy.context.scene, render_settings)
+
 
 def build_render(project_name, asset_name):
     """Build render workfile.


### PR DESCRIPTION
## Changelog Description
Removing of the animation check in the build workfile to enable all OpenPype instances in blender, even if they don't contains animations.

## Testing notes:
1. Open a new blender animation shot.
2. If there are elements in the scene, make a new general scene. (Warning: do not save and publish after this step)
3. In the OpenPype menu, click on Build first workfile.
4. Then check OpenPype instances in the OpenPype Intances tab. They should all be enabled by default.
