### PR TITLE
Bugfix: Missing frame in board reference

### DIFF
--- a/openpype/hosts/blender/plugins/load/load_image.py
+++ b/openpype/hosts/blender/plugins/load/load_image.py
@@ -167,7 +167,7 @@ class BackgroundLoader(ImageLoader):
         if img.source == "MOVIE":
             bkg_img.image_user.frame_start = bpy.context.scene.frame_start
             bkg_img.image_user.frame_duration = (
-                bpy.context.scene.frame_end - bpy.context.scene.frame_start
+                bpy.context.scene.frame_end - bpy.context.scene.frame_start + 1
             )
             # Append audio in the sequencer only if there is no sound yet
             sequences = bpy.context.scene.sequence_editor.sequences


### PR DESCRIPTION
## Changelog Description
Board reference is missing a frame in blender after build. This is due to differences between how blender and kitsu handle frame ranges.

## Testing notes:
- Build a layout workfile.
- Check that the board reference last frame isn't a duplicate of the previous frame.