### PR TITLE
Fix: Transfer 'hide_' attributes for outliner datablocks

### DIFF
--- a/openpype/hosts/blender/api/utils.py
+++ b/openpype/hosts/blender/api/utils.py
@@ -773,6 +773,11 @@ def replace_datablocks(
             if new_datablock.library:
                 continue
 
+            # Transfer hide
+            if hasattr(old_datablock, "hide_viewport"):
+                new_datablock.hide_viewport = old_datablock.hide_viewport
+                new_datablock.hide_render = old_datablock.hide_render
+
             # Transfer transforms
             if isinstance(old_datablock, bpy.types.Object):
                 new_datablock.location = old_datablock.location


### PR DESCRIPTION
`hide_` must be transferred as it is locally overridden.

## Testing notes:
1. Build `e666_sq000_sh666` anim from empty blend scene, check what is hidden
2. Open `e666_sq000_sh666` layout, change `hide_` attribute for any other outliner datablock and publish
3. Do step `1` again
