### PR TITLE
Feature: Build layout get camera variant from kitsu

### DIFF
--- a/openpype/hosts/blender/scripts/build_workfile.py
+++ b/openpype/hosts/blender/scripts/build_workfile.py
@@ -538,7 +538,7 @@ def build_layout(project_name, asset_name):
                 get_asset_by_name(
                     project_name, get_current_asset_name(), fields=["data"]
                 )["data"]["zou"]["id"]
-            )["data"]["camera"]
+            )["data"].get("camera")
 
             gazu.log_out()
 

--- a/openpype/hosts/blender/scripts/build_workfile.py
+++ b/openpype/hosts/blender/scripts/build_workfile.py
@@ -558,8 +558,6 @@ def build_layout(project_name, asset_name):
                     "exist. Falling back to `cameraMain`"
                 )
 
-            print(f"Camera subset UwU: {camera_subset_name}")
-
             # Download camera published at environment task
             cam_repre = download_subset(
                 project_name, env_asset_name, camera_subset_name


### PR DESCRIPTION
## Changelog Description
Get camera variant from kitsu during build layout. If a camera is specified on Kitsu in the camera field, and its subset exists, it will be used during build layout. If the field is left empty, `cameraMain` will be used (So it doesn't break unaffected shots). If the camera field is set, but the subset doesn't exists, it will fall back to `cameraMain`.

## Testing notes:
- Build `e108_sh002` layout.
- `camera02_A` should be loaded.
- Build any layout with an empty camera field.
- `cameraMain` should be loaded.
- Set camera to `01_A` on `e108_sh001`.
- Build `e108_sh001` layout.
- `cameraMain` should be loaded (because `camera01_A` doesn't exist).