### PR TITLE
Fix: Multicam support for build anim

### DIFF
--- a/openpype/hosts/blender/scripts/build_workfile.py
+++ b/openpype/hosts/blender/scripts/build_workfile.py
@@ -385,11 +385,14 @@ def load_references(
     return errors
 
 
-def get_camera_variant(project_name: str):
+def get_camera_variant(project_name: str) -> str:
     """Get camera_variant for current shot.
 
     Args:
         project_name (str): Project name.
+
+    Returns:
+        str: Camera variant.
     """
     import gazu
 
@@ -409,12 +412,12 @@ def get_camera_variant(project_name: str):
 
     if camera_variant:
         return camera_variant
-    else:
-        print(
-            "Camera field is either empty, or its subset doesn't "
-            "exist. Falling back to `cameraMain`"
-        )
-        return "Main"
+
+    print(
+        "Camera field is either empty, or its subset doesn't "
+        "exist. Falling back to `cameraMain`"
+    )
+    return "Main"
 
 
 def build_model(project_name, asset_name):


### PR DESCRIPTION
## Changelog Description
Allowing multicam support in build anim in the same fashion as build layout. This is necessary for shots relying on this feature, otherwise they cannot be built.

## Additional info
This comes with a slight refactor to build layout as well, so it should be tested too.

## Testing notes:
- build e108_sh003 layout AND anim.
- build any shot that doesn't use multicam support in layout AND anim.
- It should pass and use the correct camera subset in all these cases.