### PR TITLE
Feature: Task types enabling for blend playblast extraction

### DIFF
--- a/openpype/hosts/blender/plugins/publish/extract_playblast.py
+++ b/openpype/hosts/blender/plugins/publish/extract_playblast.py
@@ -23,7 +23,16 @@ class ExtractPlayblast(Extractor):
     optional = True
     order = extract_thumbnail.ExtractThumbnail.order - 0.002
 
+    task_types = []
+
     def process(self, instance):
+        # Check current task type
+        if instance.data.get("task") not in self.task_types:
+            self.log.info(
+                "Skipped instance. Current task not listed in task types."
+            )
+            return
+
         self.log.info("Extracting capture..")
 
         # get scene fps

--- a/openpype/settings/defaults/project_settings/blender.json
+++ b/openpype/settings/defaults/project_settings/blender.json
@@ -198,7 +198,7 @@
             "enabled": true,
             "optional": true,
             "active": true,
-            "task_types": [],
+            "task_types": ["Layout", "Animation"],
             "presets": {
                 "default": {
                     "image_settings": {

--- a/openpype/settings/defaults/project_settings/blender.json
+++ b/openpype/settings/defaults/project_settings/blender.json
@@ -198,6 +198,7 @@
             "enabled": true,
             "optional": true,
             "active": true,
+            "task_types": [],
             "presets": {
                 "default": {
                     "image_settings": {

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_blender_publish.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_blender_publish.json
@@ -237,6 +237,11 @@
                     "label": "Active"
                 },
                 {
+                    "key": "task_types",
+                    "label": "Task types",
+                    "type": "task-types-enum"
+                },
+                {
                     "type": "raw-json",
                     "key": "presets",
                     "label": "Presets"


### PR DESCRIPTION
This feature adds granularity on enabling blender playblast extraction for certain task types.

## Testing notes:
1. Cherry-pick on last OP studio release
2. On `prod_test`, in studio settings check or uncheck the task types as wanted.
3. Publish a workfile of a task enabled or disabled with review and check it behaves consistently. (tested on `E01_SE01_SH001`)
