### PR TITLE
Fix integrate kitsu note

### DIFF
--- a/openpype/modules/kitsu/plugins/publish/integrate_kitsu_note.py
+++ b/openpype/modules/kitsu/plugins/publish/integrate_kitsu_note.py
@@ -29,7 +29,7 @@ class IntegrateKitsuNote(pyblish.api.ContextPlugin):
     _processed_tasks = []
 
     def format_publish_comment(self, instance):
-        """Format the instance's publish comment
+        """Format the instance's publish comment.
 
         Formats `instance.data` against the custom template.
         """
@@ -81,7 +81,12 @@ class IntegrateKitsuNote(pyblish.api.ContextPlugin):
             )
 
     def skip_instance(self, context, instance, kitsu_task: dict) -> bool:
-        """Defines if the instance needs to be skipped or not."""
+        """Define if the instance needs to be skipped or not.
+
+        Returns:
+            bool: True if the instance needs to be skipped. Else False.
+        """
+        # Check already existing comment
         if context.data.get("kitsu_comment"):
             self.log.info(
                 "Kitsu comment already set, "
@@ -89,6 +94,7 @@ class IntegrateKitsuNote(pyblish.api.ContextPlugin):
             )
             return True
 
+        # Check kitsu task
         if not kitsu_task:
             self.log.warning("No kitsu task.")
             return True
@@ -98,20 +104,11 @@ class IntegrateKitsuNote(pyblish.api.ContextPlugin):
                 "skipping comment creation for instance..."
             )
             return True
+
+        # Check family and families
         families = set(
             [instance.data["family"]] + instance.data.get("families", [])
         )
-
-        try:
-            self.log.info(f"{self.family = }, {families = }")
-        except Exception:
-            pass
-
-        try:
-            self.log.info(f"{self.families = }, {families = }")
-        except Exception:
-            pass
-
         if (getattr(self, "family", None) and self.family not in families) or (
             getattr(self, "families", [])
             and not any(f in families for f in self.families)
@@ -131,7 +128,6 @@ class IntegrateKitsuNote(pyblish.api.ContextPlugin):
         for instance in context:
             kitsu_task = instance.data.get("kitsu_task")
             if self.skip_instance(context, instance, kitsu_task):
-                self.log.info(f"Skip instance {instance}")
                 continue
 
             # Get note status, by default uses the task status for the note
@@ -172,12 +168,6 @@ class IntegrateKitsuNote(pyblish.api.ContextPlugin):
 
                     if allow_status_change:
                         break
-
-            self.log.info("----------------- DATA")
-            self.log.info(f"{self.set_status_note = }")
-            self.log.info(f"{self.note_status_shortname = }")
-            self.log.info(f"{self.status_change_conditions = }")
-            self.log.info(f"{allow_status_change = }")
 
             # Set note status
             if self.set_status_note and allow_status_change:

--- a/openpype/modules/kitsu/plugins/publish/integrate_kitsu_note.py
+++ b/openpype/modules/kitsu/plugins/publish/integrate_kitsu_note.py
@@ -63,20 +63,18 @@ class IntegrateKitsuNote(pyblish.api.ContextPlugin):
             .get(self.__class__.__name__, {})
         )
 
-        settings_from_context = []
+        settings_from_context = {}
         if kitsu_note.get("set_status_note") != self.set_status_note:
             self.set_status_note = kitsu_note["set_status_note"]
-            settings_from_context.append(
-                ("set_status_note", self.set_status_note)
-            )
+            settings_from_context["set_status_note"] = self.set_status_note
 
         if (
             kitsu_note.get("note_status_shortname")
             != self.note_status_shortname
         ):
             self.note_status_shortname = kitsu_note["note_status_shortname"]
-            settings_from_context.append(
-                ("note_status_shortname", self.note_status_shortname)
+            settings_from_context["note_status_shortname"] = (
+                self.note_status_shortname
             )
 
         if (
@@ -86,8 +84,8 @@ class IntegrateKitsuNote(pyblish.api.ContextPlugin):
             self.status_change_conditions = kitsu_note[
                 "status_change_conditions"
             ]
-            settings_from_context.append(
-                ("status_change_conditions", self.status_change_conditions)
+            settings_from_context["status_change_conditions"] = (
+                self.status_change_conditions
             )
 
         if settings_from_context:
@@ -95,8 +93,8 @@ class IntegrateKitsuNote(pyblish.api.ContextPlugin):
                 "Following settings were loaded from context as they were "
                 "different from loaded project settings."
             )
-            for setting in settings_from_context:
-                self.log.info(f"- {setting[0]}: {setting[1]}")
+            for setting_name, setting_value in settings_from_context.items():
+                self.log.info(f"- {setting_name}: {setting_value}")
 
     def skip_instance(self, context, instance, kitsu_task: dict) -> bool:
         """Define if the instance needs to be skipped or not.

--- a/openpype/modules/kitsu/plugins/publish/integrate_kitsu_note.py
+++ b/openpype/modules/kitsu/plugins/publish/integrate_kitsu_note.py
@@ -62,16 +62,23 @@ class IntegrateKitsuNote(pyblish.api.ContextPlugin):
             .get("publish", {})
             .get(self.__class__.__name__, {})
         )
-        get_from_context = False
+
+        settings_from_context = []
         if kitsu_note.get("set_status_note") != self.set_status_note:
             self.set_status_note = kitsu_note["set_status_note"]
-            get_from_context = True
+            settings_from_context.append(
+                ("set_status_note", self.set_status_note)
+            )
+
         if (
             kitsu_note.get("note_status_shortname")
             != self.note_status_shortname
         ):
             self.note_status_shortname = kitsu_note["note_status_shortname"]
-            get_from_context = True
+            settings_from_context.append(
+                ("note_status_shortname", self.note_status_shortname)
+            )
+
         if (
             kitsu_note.get("status_change_conditions")
             != self.status_change_conditions
@@ -79,13 +86,17 @@ class IntegrateKitsuNote(pyblish.api.ContextPlugin):
             self.status_change_conditions = kitsu_note[
                 "status_change_conditions"
             ]
-            get_from_context = True
+            settings_from_context.append(
+                ("status_change_conditions", self.status_change_conditions)
+            )
 
-        if get_from_context:
+        if settings_from_context:
             self.log.info(
-                "Settings were loaded from context as they are "
+                "Following settings were loaded from context as they were "
                 "different from loaded project settings."
             )
+            for setting in settings_from_context:
+                self.log.info(f"- {setting[0]}: {setting[1]}")
 
     def skip_instance(self, context, instance, kitsu_task: dict) -> bool:
         """Define if the instance needs to be skipped or not.

--- a/openpype/modules/kitsu/plugins/publish/integrate_kitsu_note.py
+++ b/openpype/modules/kitsu/plugins/publish/integrate_kitsu_note.py
@@ -25,6 +25,9 @@ class IntegrateKitsuNote(pyblish.api.ContextPlugin):
         "comment_template": "{comment}",
     }
 
+    # private
+    _processed_tasks = []
+
     def format_publish_comment(self, instance):
         """Format the instance's publish comment
 
@@ -48,18 +51,87 @@ class IntegrateKitsuNote(pyblish.api.ContextPlugin):
         pattern = r"\{([^}]*)\}"
         return re.sub(pattern, replace_missing_key, template)
 
-    def process(self, context):
-        for instance in context:
-            # Check if instance is a review by checking its family
-            # Allow a match to primary family or any of families
-            families = set(
-                [instance.data["family"]] + instance.data.get("families", [])
-            )
-            if "review" not in families:
-                continue
+    def get_settings_from_context(self, context):
+        """Get settings from context if they're different.
 
+        As we sometimes have wrong loaded settings in this integrator,
+        but have the good ones loaded in the context, it's better to use them.
+        """
+        kitsu_note = (
+            context.data["project_settings"]
+            .get("kitsu", {})
+            .get("publish", {})
+            .get(self.__class__.__name__, {})
+        )
+        if (
+            kitsu_note.get("set_status_note") != self.set_status_note,
+            kitsu_note.get("note_status_shortname")
+            != self.note_status_shortname,
+            kitsu_note.get("status_change_conditions")
+            != self.status_change_conditions,
+        ):
+            self.set_status_note = kitsu_note["set_status_note"]
+            self.note_status_shortname = kitsu_note["note_status_shortname"]
+            self.status_change_conditions = kitsu_note[
+                "status_change_conditions"
+            ]
+            self.log.info(
+                "Settings were loaded from context as they are "
+                "different from loaded project settings."
+            )
+
+    def skip_instance(self, context, instance, kitsu_task: dict) -> bool:
+        """Defines if the instance needs to be skipped or not."""
+        if context.data.get("kitsu_comment"):
+            self.log.info(
+                "Kitsu comment already set, "
+                "skipping comment creation for instance..."
+            )
+            return True
+
+        if not kitsu_task:
+            self.log.warning("No kitsu task.")
+            return True
+        elif kitsu_task in self._processed_tasks:
+            self.log.info(
+                "Kitsu task already processed, "
+                "skipping comment creation for instance..."
+            )
+            return True
+        families = set(
+            [instance.data["family"]] + instance.data.get("families", [])
+        )
+
+        try:
+            self.log.info(f"{self.family = }, {families = }")
+        except Exception:
+            pass
+
+        try:
+            self.log.info(f"{self.families = }, {families = }")
+        except Exception:
+            pass
+
+        if (getattr(self, "family", None) and self.family not in families) or (
+            getattr(self, "families", [])
+            and not any(f in families for f in self.families)
+        ):
+            self.log.info(
+                "Instance family or families doesn't match integrator, "
+                "skipping comment creation for instance..."
+            )
+            return True
+        return False
+
+    def process(self, context):
+        # Force Kitsu note settings as they're sometimes
+        # not loaded correctly when using rez
+        self.get_settings_from_context(context)
+
+        for instance in context:
             kitsu_task = instance.data.get("kitsu_task")
-            if not kitsu_task:
+            if self.skip_instance(context, instance, kitsu_task):
+                self.log.info(f"Skip instance {instance}")
                 continue
 
             # Get note status, by default uses the task status for the note
@@ -101,6 +173,12 @@ class IntegrateKitsuNote(pyblish.api.ContextPlugin):
                     if allow_status_change:
                         break
 
+            self.log.info("----------------- DATA")
+            self.log.info(f"{self.set_status_note = }")
+            self.log.info(f"{self.note_status_shortname = }")
+            self.log.info(f"{self.status_change_conditions = }")
+            self.log.info(f"{allow_status_change = }")
+
             # Set note status
             if self.set_status_note and allow_status_change:
                 kitsu_status = gazu.task.get_task_status_by_short_name(
@@ -111,9 +189,14 @@ class IntegrateKitsuNote(pyblish.api.ContextPlugin):
                     self.log.info("Note Kitsu status: {}".format(note_status))
                 else:
                     self.log.info(
-                        "Cannot find {} status. The status will not be "
-                        "changed!".format(self.note_status_shortname)
+                        f"Cannot find {self.note_status_shortname} status. "
+                        f"The status will not be changed!"
                     )
+            else:
+                self.log.info(
+                    "Don't update status note. "
+                    f"{self.set_status_note = }, {allow_status_change = }"
+                )
 
             # Get comment text body
             publish_comment = instance.data.get("comment")
@@ -133,4 +216,5 @@ class IntegrateKitsuNote(pyblish.api.ContextPlugin):
                 kitsu_task, note_status, comment=publish_comment
             )
 
-            instance.data["kitsu_comment"] = kitsu_comment
+            context.data["kitsu_comment"] = kitsu_comment
+            self._processed_tasks.append(kitsu_task)

--- a/openpype/modules/kitsu/plugins/publish/integrate_kitsu_note.py
+++ b/openpype/modules/kitsu/plugins/publish/integrate_kitsu_note.py
@@ -25,7 +25,6 @@ class IntegrateKitsuNote(pyblish.api.ContextPlugin):
         "comment_template": "{comment}",
     }
 
-    # private
     _processed_tasks = []
 
     def format_publish_comment(self, instance):
@@ -63,18 +62,26 @@ class IntegrateKitsuNote(pyblish.api.ContextPlugin):
             .get("publish", {})
             .get(self.__class__.__name__, {})
         )
-        if (
-            kitsu_note.get("set_status_note") != self.set_status_note,
-            kitsu_note.get("note_status_shortname")
-            != self.note_status_shortname,
-            kitsu_note.get("status_change_conditions")
-            != self.status_change_conditions,
-        ):
+        get_from_context = False
+        if kitsu_note.get("set_status_note") != self.set_status_note:
             self.set_status_note = kitsu_note["set_status_note"]
+            get_from_context = True
+        if (
+            kitsu_note.get("note_status_shortname")
+            != self.note_status_shortname
+        ):
             self.note_status_shortname = kitsu_note["note_status_shortname"]
+            get_from_context = True
+        if (
+            kitsu_note.get("status_change_conditions")
+            != self.status_change_conditions
+        ):
             self.status_change_conditions = kitsu_note[
                 "status_change_conditions"
             ]
+            get_from_context = True
+
+        if get_from_context:
             self.log.info(
                 "Settings were loaded from context as they are "
                 "different from loaded project settings."


### PR DESCRIPTION
# Purpose

Fix two bugs:
- Settings are not loaded
- IntegrateKitsuNoteWorkfileOnly doesn't work because of this parent class

## Changes

- Separate reasons to skip an instance into a new method to allow different skip methods for each inherinting class
- Store the "kitsu_comment" data onto the context to avoid adding kitsu notes for multiple instances
- Never add a note on an already annoted task
- Fix problem with families/family: the note update will only happen if the instance.data["family"] or ["families"] matches class family or families
- 