### PR TITLE
Feature: Allow comment update for Kitsu Note

### DIFF
--- a/openpype/modules/kitsu/plugins/publish/integrate_kitsu_comment.py
+++ b/openpype/modules/kitsu/plugins/publish/integrate_kitsu_comment.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+import gazu
+import pyblish.api
+import re
+
+from openpype.modules.kitsu.plugins.publish import integrate_kitsu_note
+
+
+class IntegrateKitsuComment(pyblish.api.InstancePlugin):
+    """Integrate Kitsu Comment"""
+
+    order = integrate_kitsu_note.IntegrateKitsuNote.order + 0.00001
+    label = "Kitsu Comment"
+    families = integrate_kitsu_note.IntegrateKitsuNote.families
+
+    # comment settings
+    custom_comment_template = {
+        "enabled": False,
+        "comment_template": "{comment}",
+    }
+
+    def format_publish_comment(self, instance):
+        """Format the instance's publish comment.
+
+        Formats `instance.data` against the custom template.
+        """
+
+        def replace_missing_key(match):
+            """If key is not found in kwargs, set None instead"""
+            key = match.group(1)
+            if key not in instance.data:
+                self.log.warning(
+                    "Key '{}' was not found in instance.data "
+                    "and will be rendered as an empty string "
+                    "in the comment".format(key)
+                )
+                return ""
+            else:
+                return str(instance.data[key])
+
+        template = self.custom_comment_template["comment_template"]
+        pattern = r"\{([^}]*)\}"
+        return re.sub(pattern, replace_missing_key, template)
+
+    def process(self, instance):
+        # Check instance has comment
+        if not (kitsu_comment := instance.data.get("kitsu_comment")):
+            self.log.info(
+                "No Kitsu comment found, skipping comment update for "
+                f"instance {instance.data['family']}"
+            )
+
+        # Get comment text body
+        instance_comment = instance.data.get("comment", "")
+        if self.custom_comment_template["enabled"]:
+            instance_comment = self.format_publish_comment(instance)
+
+        if not instance_comment:
+            self.log.info("Comment is not set.")
+        else:
+            self.log.debug(f"Comment is `{instance_comment}`")
+
+        # Check if comment must be updated
+        if kitsu_comment["text"] != instance_comment:
+            self.log.info(
+                "Kitsu comment is different from the one in the instance, "
+                "updating comment..."
+            )
+
+            kitsu_comment["text"] = instance_comment
+
+        # Check if comment status must be updated
+        note_status_shortname = instance.data.get("note_status_shortname")
+        if (
+            note_status_shortname
+            and note_status_shortname
+            != kitsu_comment["task_status"]["short_name"]
+        ):
+            self.log.info(
+                "Kitsu comment status is different from the one in the instance, "
+                "updating comment status..."
+            )
+            if kitsu_status := gazu.task.get_task_status_by_short_name(
+                note_status_shortname
+            ):
+                kitsu_comment["task_status"] = kitsu_status
+                self.log.info(f"Note Kitsu status: {kitsu_status}")
+            else:
+                self.log.info(
+                    f"Cannot find {note_status_shortname} status. "
+                    f"The status will not be changed!"
+                )
+
+        # Update comment in kitsu task
+        gazu.task.update_comment(kitsu_comment)

--- a/openpype/modules/kitsu/plugins/publish/integrate_kitsu_comment.py
+++ b/openpype/modules/kitsu/plugins/publish/integrate_kitsu_comment.py
@@ -3,15 +3,15 @@ import gazu
 import pyblish.api
 import re
 
-from openpype.modules.kitsu.plugins.publish import integrate_kitsu_note
+from openpype.modules.kitsu.plugins.publish import integrate_kitsu_review
 
 
 class IntegrateKitsuComment(pyblish.api.InstancePlugin):
     """Integrate Kitsu Comment"""
 
-    order = integrate_kitsu_note.IntegrateKitsuNote.order + 0.00001
+    order = integrate_kitsu_review.IntegrateKitsuReview.order
     label = "Kitsu Comment"
-    families = integrate_kitsu_note.IntegrateKitsuNote.families
+    families = integrate_kitsu_review.IntegrateKitsuReview.families
 
     # comment settings
     custom_comment_template = {

--- a/openpype/modules/kitsu/plugins/publish/integrate_kitsu_comment.py
+++ b/openpype/modules/kitsu/plugins/publish/integrate_kitsu_comment.py
@@ -77,8 +77,8 @@ class IntegrateKitsuComment(pyblish.api.InstancePlugin):
             != kitsu_comment["task_status"]["short_name"]
         ):
             self.log.info(
-                "Kitsu comment status is different from the one in the instance, "
-                "updating comment status..."
+                "Kitsu comment status is different from the one in the "
+                "instance, updating comment status..."
             )
             if kitsu_status := gazu.task.get_task_status_by_short_name(
                 note_status_shortname

--- a/openpype/settings/defaults/project_settings/kitsu.json
+++ b/openpype/settings/defaults/project_settings/kitsu.json
@@ -11,7 +11,9 @@
             "status_change_conditions": {
                 "status_conditions": [],
                 "family_requirements": []
-            },
+            }
+        },
+        "IntegrateKitsuComment": {
             "custom_comment_template": {
                 "enabled": false,
                 "comment_template": "{comment}\n\n|  |  |\n|--|--|\n| version| `{version}` |\n| family | `{family}` |\n| name | `{name}` |"

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_kitsu.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_kitsu.json
@@ -110,7 +110,15 @@
                                     }
                                 }
                             ]
-                        },
+                        }
+                    ]
+                },
+                {
+                    "type": "dict",
+                    "collapsible": true,
+                    "key": "IntegrateKitsuComment",
+                    "label": "Integrate Kitsu Comment",
+                    "children": [
                         {
                             "type": "dict",
                             "collapsible": true,


### PR DESCRIPTION
To be able to update a comment in a later publish, we have to split the note creation and the comment content update.  
For example, publishing a note with a render sent to a farm may need a note update in a second process, for displaying that the render has complete.

## Testing notes:
1. Move this code on last beta we have
2. Publish layout for `e666_sh005`, it should work as previously
3. You can monitor Kitsu and see that the note is created first and then the comment content updated.
