### PR TITLE
Feature: Store kitsu user connection

### DIFF
--- a/openpype/modules/kitsu/plugins/publish/collect_kitsu_credential.py
+++ b/openpype/modules/kitsu/plugins/publish/collect_kitsu_credential.py
@@ -14,4 +14,8 @@ class CollectKitsuSession(pyblish.api.ContextPlugin):  # rename log in
 
     def process(self, context):
         gazu.client.set_host(os.environ["KITSU_SERVER"])
-        gazu.log_in(os.environ["KITSU_LOGIN"], os.environ["KITSU_PWD"])
+
+        # Log in to Kitsu and store user data
+        context.data["kitsu_user"] = gazu.log_in(
+            os.environ["KITSU_LOGIN"], os.environ["KITSU_PWD"]
+        ).get("user")


### PR DESCRIPTION
Having the logged-in user may be useful, to tag it in Kitsu within another process for example.

## Testing notes:
1. Collect step in publish shouldn't fail, that's all
